### PR TITLE
Add support for CreateIfNotExist when invoking actors

### DIFF
--- a/virtual/benchmarks_test.go
+++ b/virtual/benchmarks_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/richardartoul/nola/virtual/registry"
-	"github.com/richardartoul/nola/wapcutils"
+	"github.com/richardartoul/nola/virtual/types"
 
 	"github.com/stretchr/testify/require"
 )
@@ -51,14 +51,14 @@ func benchmarkInvokeActor(b *testing.B, reg registry.Registry) {
 	_, err = reg.RegisterModule(ctx, "bench-ns", "test-module", utilWasmBytes, registry.ModuleOptions{})
 	require.NoError(b, err)
 
-	_, err = reg.CreateActor(ctx, "bench-ns", "a", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "bench-ns", "a", "test-module", types.ActorOptions{})
 	require.NoError(b, err)
 
 	defer reportOpsPerSecond(b)()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err = env.InvokeActor(ctx, "bench-ns", "a", "incFast", nil)
+		_, err = env.InvokeActor(ctx, "bench-ns", "a", "incFast", nil, types.CreateIfNotExist{})
 		if err != nil {
 			panic(err)
 		}
@@ -102,7 +102,7 @@ func BenchmarkLocalCreateActor(b *testing.B) {
 	defer reportOpsPerSecond(b)()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = reg.CreateActor(ctx, "bench-ns", fmt.Sprintf("%d", i), "test-module", registry.ActorOptions{})
+		_, err = reg.CreateActor(ctx, "bench-ns", fmt.Sprintf("%d", i), "test-module", types.ActorOptions{})
 		if err != nil {
 			panic(err)
 		}
@@ -124,11 +124,11 @@ func BenchmarkLocalCreateThenInvokeActor(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		actorID := fmt.Sprintf("%d", i)
-		_, err = reg.CreateActor(ctx, "bench-ns", actorID, "test-module", registry.ActorOptions{})
+		_, err = reg.CreateActor(ctx, "bench-ns", actorID, "test-module", types.ActorOptions{})
 		if err != nil {
 			panic(err)
 		}
-		_, err = env.InvokeActor(ctx, "bench-ns", actorID, "incFast", nil)
+		_, err = env.InvokeActor(ctx, "bench-ns", actorID, "incFast", nil, types.CreateIfNotExist{})
 		if err != nil {
 			panic(err)
 		}
@@ -146,12 +146,12 @@ func BenchmarkLocalActorToActorCommunication(b *testing.B) {
 	_, err = reg.RegisterModule(ctx, "bench-ns", "test-module", utilWasmBytes, registry.ModuleOptions{})
 	require.NoError(b, err)
 
-	_, err = reg.CreateActor(ctx, "bench-ns", "a", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "bench-ns", "a", "test-module", types.ActorOptions{})
 	require.NoError(b, err)
-	_, err = reg.CreateActor(ctx, "bench-ns", "b", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "bench-ns", "b", "test-module", types.ActorOptions{})
 	require.NoError(b, err)
 
-	invokeReq := wapcutils.InvokeActorRequest{
+	invokeReq := types.InvokeActorRequest{
 		ActorID:   "b",
 		Operation: "incFast",
 		Payload:   nil,
@@ -162,7 +162,7 @@ func BenchmarkLocalActorToActorCommunication(b *testing.B) {
 	defer reportOpsPerSecond(b)()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = env.InvokeActor(ctx, "bench-ns", "a", "invokeActor", marshaled)
+		_, err = env.InvokeActor(ctx, "bench-ns", "a", "invokeActor", marshaled, types.CreateIfNotExist{})
 		if err != nil {
 			panic(err)
 		}
@@ -210,14 +210,14 @@ func testSimpleBench(
 
 	for i := 0; i < numActors; i++ {
 		actorID := fmt.Sprintf("%d", i)
-		_, err = reg.CreateActor(context.Background(), "bench-ns", actorID, "test-module", registry.ActorOptions{})
+		_, err = reg.CreateActor(context.Background(), "bench-ns", actorID, "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
 		if useWorker {
 			_, err = env.InvokeWorker(context.Background(), "bench-ns", "test-module", "incFast", nil)
 			require.NoError(t, err)
 		} else {
-			_, err = env.InvokeActor(context.Background(), "bench-ns", actorID, "incFast", nil)
+			_, err = env.InvokeActor(context.Background(), "bench-ns", actorID, "incFast", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 		}
 	}
@@ -249,7 +249,7 @@ func testSimpleBench(
 					start := time.Now()
 					if !useWorker {
 						actorID := fmt.Sprintf("%d", i%numActors)
-						_, err = env.InvokeActor(ctx, "bench-ns", actorID, "incFast", nil)
+						_, err = env.InvokeActor(ctx, "bench-ns", actorID, "incFast", nil, types.CreateIfNotExist{})
 						if err != nil {
 							panic(err)
 						}

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -57,21 +57,55 @@ func TestSimpleActor(t *testing.T) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
 			// Can't invoke because actor doesn't exist yet.
-			_, err := env.InvokeActor(ctx, ns, "a", "inc", nil)
+			_, err := env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 			require.Error(t, err)
 
 			// Create actor.
-			_, err = reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err = reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
 			for i := 0; i < 100; i++ {
 				// Invoke should work now.
-				result, err := env.InvokeActor(ctx, ns, "a", "inc", nil)
+				result, err := env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 				require.NoError(t, err)
 				require.Equal(t, int64(i+1), getCount(t, result))
 
 				if i == 0 {
-					result, err = env.InvokeActor(ctx, ns, "a", "getStartupWasCalled", nil)
+					result, err = env.InvokeActor(ctx, ns, "a", "getStartupWasCalled", nil, types.CreateIfNotExist{})
+					require.NoError(t, err)
+					require.Equal(t, []byte("true"), result)
+				}
+			}
+		}
+	}
+
+	runWithDifferentConfigs(t, testFn)
+}
+
+// TestCreateIfNotExist tests that the CreateIfNotExist argument can be used to invoke an actor and
+// create it automatically if it does not already exist.
+func TestCreateIfNotExist(t *testing.T) {
+	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
+		ctx := context.Background()
+		for _, ns := range []string{"ns-1", "ns-2"} {
+			// No create actor call before invoking.
+			for i := 0; i < 100; i++ {
+				if i == 0 {
+					// Invoke should fail if CreateIfNotExist is not set.
+					_, err := env.InvokeActor(
+						ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
+					require.Error(t, err)
+					require.True(t, registry.IsActorDoesNotExistErr(err))
+				}
+
+				// Should succeed with it set.
+				result, err := env.InvokeActor(
+					ctx, ns, "a", "inc", nil, types.CreateIfNotExist{ModuleID: "test-module"})
+				require.NoError(t, err)
+				require.Equal(t, int64(i+1), getCount(t, result))
+
+				if i == 0 {
+					result, err = env.InvokeActor(ctx, ns, "a", "getStartupWasCalled", nil, types.CreateIfNotExist{})
 					require.NoError(t, err)
 					require.Equal(t, []byte("true"), result)
 				}
@@ -119,12 +153,12 @@ func TestGenerationCountIncInvalidatesActivation(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
-			_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
 			// Build some state.
 			for i := 0; i < 100; i++ {
-				result, err := env.InvokeActor(ctx, ns, "a", "inc", nil)
+				result, err := env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 				require.NoError(t, err)
 				require.Equal(t, int64(i+1), getCount(t, result))
 			}
@@ -137,7 +171,7 @@ func TestGenerationCountIncInvalidatesActivation(t *testing.T) {
 				if i == 0 {
 					for {
 						// Wait for cache to expire.
-						result, err := env.InvokeActor(ctx, ns, "a", "inc", nil)
+						result, err := env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 						require.NoError(t, err)
 						if getCount(t, result) == 1 {
 							break
@@ -146,7 +180,7 @@ func TestGenerationCountIncInvalidatesActivation(t *testing.T) {
 					}
 					continue
 				}
-				result, err := env.InvokeActor(ctx, ns, "a", "inc", nil)
+				result, err := env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 				require.NoError(t, err)
 				require.Equal(t, int64(i+1), getCount(t, result))
 			}
@@ -168,27 +202,27 @@ func TestKVHostFunctions(t *testing.T) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
 			if count == 0 {
-				_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+				_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 				require.NoError(t, err)
 
 				for i := 0; i < 100; i++ {
-					_, err := env.InvokeActor(ctx, ns, "a", "inc", nil)
+					_, err := env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 					require.NoError(t, err)
 
 					// Write the current count to a key.
 					key := []byte(fmt.Sprintf("key-%d", i))
-					_, err = env.InvokeActor(ctx, ns, "a", "kvPutCount", key)
+					_, err = env.InvokeActor(ctx, ns, "a", "kvPutCount", key, types.CreateIfNotExist{})
 					require.NoError(t, err)
 
 					// Read the key back and make sure the value is == the count
-					payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key)
+					payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key, types.CreateIfNotExist{})
 					require.NoError(t, err)
 					val := getCount(t, payload)
 					require.Equal(t, int64(i+1), val)
 
 					if i > 0 {
 						key := []byte(fmt.Sprintf("key-%d", i-1))
-						payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key)
+						payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key, types.CreateIfNotExist{})
 						require.NoError(t, err)
 						val := getCount(t, payload)
 						require.Equal(t, int64(i), val)
@@ -199,7 +233,7 @@ func TestKVHostFunctions(t *testing.T) {
 			// Ensure all previous KV are still readable.
 			for i := 0; i < 100; i++ {
 				key := []byte(fmt.Sprintf("key-%d", i))
-				payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key)
+				payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key, types.CreateIfNotExist{})
 				require.NoError(t, err)
 				val := getCount(t, payload)
 				require.Equal(t, int64(i+1), val)
@@ -220,19 +254,19 @@ func TestKVTransactions(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1"} {
-			_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
-			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Write the current count to a key.
 			key := []byte("key")
-			_, err = env.InvokeActor(ctx, ns, "a", "kvPutCount", key)
+			_, err = env.InvokeActor(ctx, ns, "a", "kvPutCount", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Read the key back and make sure the value is == the count
-			payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key)
+			payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			val := getCount(t, payload)
 			require.Equal(t, int64(1), val)
@@ -241,14 +275,14 @@ func TestKVTransactions(t *testing.T) {
 			// returns an error so the updated counter will not be committed to
 			// KV storage. This tests that implicit KV transactions are rolled
 			// back if the actor returns an error.
-			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
-			_, err = env.InvokeActor(ctx, ns, "a", "kvPutCountError", key)
+			_, err = env.InvokeActor(ctx, ns, "a", "kvPutCountError", key, types.CreateIfNotExist{})
 			require.True(t, strings.Contains(err.Error(), "some fake error"), err.Error())
 
 			// Count should still be 1.
-			payload, err = env.InvokeActor(ctx, ns, "a", "kvGet", key)
+			payload, err = env.InvokeActor(ctx, ns, "a", "kvGet", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			val = getCount(t, payload)
 			require.Equal(t, int64(1), val)
@@ -268,35 +302,35 @@ func TestKVHostFunctionsActorsSeparatedRegression(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
-			_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
-			_, err = reg.CreateActor(ctx, ns, "b", "test-module", registry.ActorOptions{})
+			_, err = reg.CreateActor(ctx, ns, "b", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
 			// Inc a twice, but b once.
-			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
-			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
-			_, err = env.InvokeActor(ctx, ns, "b", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "b", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			key := []byte("key")
 
 			// Persist each actor's count.
-			_, err = env.InvokeActor(ctx, ns, "a", "kvPutCount", key)
+			_, err = env.InvokeActor(ctx, ns, "a", "kvPutCount", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
-			_, err = env.InvokeActor(ctx, ns, "b", "kvPutCount", key)
+			_, err = env.InvokeActor(ctx, ns, "b", "kvPutCount", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Make sure we can read back the independent counts.
-			payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key)
+			payload, err := env.InvokeActor(ctx, ns, "a", "kvGet", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			val := getCount(t, payload)
 			require.Equal(t, int64(2), val)
 
-			payload, err = env.InvokeActor(ctx, ns, "b", "kvGet", key)
+			payload, err = env.InvokeActor(ctx, ns, "b", "kvGet", key, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			val = getCount(t, payload)
 			require.Equal(t, int64(1), val)
@@ -312,37 +346,37 @@ func TestCreateActorHostFunction(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
-			_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
 			// Succeeds because actor exists.
-			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "a", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Fails because actor does not exist.
-			_, err = env.InvokeActor(ctx, ns, "b", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "b", "inc", nil, types.CreateIfNotExist{})
 			require.Error(t, err)
 
 			// Create a new actor b by calling fork() on a, not by creating it ourselves.
-			_, err = env.InvokeActor(ctx, ns, "a", "fork", []byte("b"))
+			_, err = env.InvokeActor(ctx, ns, "a", "fork", []byte("b"), types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Should succeed now that actor a has created actor b.
-			_, err = env.InvokeActor(ctx, ns, "b", "inc", nil)
+			_, err = env.InvokeActor(ctx, ns, "b", "inc", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			for _, actor := range []string{"a", "b"} {
 				for i := 0; i < 100; i++ {
-					_, err := env.InvokeActor(ctx, ns, actor, "inc", nil)
+					_, err := env.InvokeActor(ctx, ns, actor, "inc", nil, types.CreateIfNotExist{})
 					require.NoError(t, err)
 
 					// Write the current count to a key.
 					key := []byte(fmt.Sprintf("key-%d", i))
-					_, err = env.InvokeActor(ctx, ns, actor, "kvPutCount", key)
+					_, err = env.InvokeActor(ctx, ns, actor, "kvPutCount", key, types.CreateIfNotExist{})
 					require.NoError(t, err)
 
 					// Read the key back and make sure the value is == the count
-					payload, err := env.InvokeActor(ctx, ns, actor, "kvGet", key)
+					payload, err := env.InvokeActor(ctx, ns, actor, "kvGet", key, types.CreateIfNotExist{})
 					require.NoError(t, err)
 					val := getCount(t, payload)
 					require.Equal(t, int64(i+2), val)
@@ -362,55 +396,55 @@ func TestInvokeActorHostFunction(t *testing.T) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
 			// Create an actor, then immediately fork it so we have two actors.
-			_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
-			_, err = env.InvokeActor(ctx, ns, "a", "fork", []byte("b"))
+			_, err = env.InvokeActor(ctx, ns, "a", "fork", []byte("b"), types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Ensure actor a can communicate with actor b.
-			invokeReq := wapcutils.InvokeActorRequest{
+			invokeReq := types.InvokeActorRequest{
 				ActorID:   "b",
 				Operation: "inc",
 				Payload:   nil,
 			}
 			marshaled, err := json.Marshal(invokeReq)
 			require.NoError(t, err)
-			_, err = env.InvokeActor(ctx, ns, "a", "invokeActor", marshaled)
+			_, err = env.InvokeActor(ctx, ns, "a", "invokeActor", marshaled, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Ensure actor b can communicate with actor a.
-			invokeReq = wapcutils.InvokeActorRequest{
+			invokeReq = types.InvokeActorRequest{
 				ActorID:   "a",
 				Operation: "inc",
 				Payload:   nil,
 			}
 			marshaled, err = json.Marshal(invokeReq)
 			require.NoError(t, err)
-			_, err = env.InvokeActor(ctx, ns, "b", "invokeActor", marshaled)
+			_, err = env.InvokeActor(ctx, ns, "b", "invokeActor", marshaled, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Ensure both actor's state was actually updated and they can request
 			// each other's state.
-			invokeReq = wapcutils.InvokeActorRequest{
+			invokeReq = types.InvokeActorRequest{
 				ActorID:   "b",
 				Operation: "getCount",
 				Payload:   nil,
 			}
 			marshaled, err = json.Marshal(invokeReq)
 			require.NoError(t, err)
-			result, err := env.InvokeActor(ctx, ns, "a", "invokeActor", marshaled)
+			result, err := env.InvokeActor(ctx, ns, "a", "invokeActor", marshaled, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			require.Equal(t, int64(1), getCount(t, result))
 
-			invokeReq = wapcutils.InvokeActorRequest{
+			invokeReq = types.InvokeActorRequest{
 				ActorID:   "a",
 				Operation: "getCount",
 				Payload:   nil,
 			}
 			marshaled, err = json.Marshal(invokeReq)
 			require.NoError(t, err)
-			result, err = env.InvokeActor(ctx, ns, "b", "invokeActor", marshaled)
+			result, err = env.InvokeActor(ctx, ns, "b", "invokeActor", marshaled, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			require.Equal(t, int64(1), getCount(t, result))
 		}
@@ -426,16 +460,16 @@ func TestScheduleInvocationHostFunction(t *testing.T) {
 		ctx := context.Background()
 		for _, ns := range []string{"ns-1", "ns-2"} {
 			// Create an actor, then immediately fork it so we have two actors.
-			_, err := reg.CreateActor(ctx, ns, "a", "test-module", registry.ActorOptions{})
+			_, err := reg.CreateActor(ctx, ns, "a", "test-module", types.ActorOptions{})
 			require.NoError(t, err)
 
-			_, err = env.InvokeActor(ctx, ns, "a", "fork", []byte("b"))
+			_, err = env.InvokeActor(ctx, ns, "a", "fork", []byte("b"), types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// A bit meta, but tell a to schedule an invocation on b to schedule an invocation
 			// back on a. This ensures that actor's can schedule invocations on other actors.
 			bScheduleA := wapcutils.ScheduleInvocationRequest{
-				Invoke: wapcutils.InvokeActorRequest{
+				Invoke: types.InvokeActorRequest{
 					ActorID:   "a",
 					Operation: "inc",
 					Payload:   nil,
@@ -445,7 +479,7 @@ func TestScheduleInvocationHostFunction(t *testing.T) {
 			marshaledBScheduleA, err := json.Marshal(bScheduleA)
 			require.NoError(t, err)
 			aScheduleB := wapcutils.ScheduleInvocationRequest{
-				Invoke: wapcutils.InvokeActorRequest{
+				Invoke: types.InvokeActorRequest{
 					ActorID:   "b",
 					Operation: "scheduleInvocation",
 					Payload:   marshaledBScheduleA,
@@ -458,7 +492,7 @@ func TestScheduleInvocationHostFunction(t *testing.T) {
 			// In addition, tell a to schedule an invocation on itself to ensure we
 			// can support "self timers".
 			aScheduleA := wapcutils.ScheduleInvocationRequest{
-				Invoke: wapcutils.InvokeActorRequest{
+				Invoke: types.InvokeActorRequest{
 					ActorID:   "a",
 					Operation: "inc",
 					Payload:   nil,
@@ -469,19 +503,19 @@ func TestScheduleInvocationHostFunction(t *testing.T) {
 			require.NoError(t, err)
 
 			// Schedule both the a::a invocation and the a::b::a invocation.
-			_, err = env.InvokeActor(ctx, ns, "a", "scheduleInvocation", marshaledAScheduleB)
+			_, err = env.InvokeActor(ctx, ns, "a", "scheduleInvocation", marshaledAScheduleB, types.CreateIfNotExist{})
 			require.NoError(t, err)
-			_, err = env.InvokeActor(ctx, ns, "a", "scheduleInvocation", marshaledAScheduleA)
+			_, err = env.InvokeActor(ctx, ns, "a", "scheduleInvocation", marshaledAScheduleA, types.CreateIfNotExist{})
 			require.NoError(t, err)
 
 			// Make sure a is 0 immediately after scheduling.
-			result, err := env.InvokeActor(ctx, ns, "a", "getCount", nil)
+			result, err := env.InvokeActor(ctx, ns, "a", "getCount", nil, types.CreateIfNotExist{})
 			require.NoError(t, err)
 			require.Equal(t, int64(0), getCount(t, result))
 
 			// Wait for both the a::a and a::b::a invocations to run.
 			for {
-				result, err := env.InvokeActor(ctx, ns, "a", "getCount", nil)
+				result, err := env.InvokeActor(ctx, ns, "a", "getCount", nil, types.CreateIfNotExist{})
 				require.NoError(t, err)
 				if getCount(t, result) != int64(2) {
 					time.Sleep(100 * time.Millisecond)
@@ -489,7 +523,7 @@ func TestScheduleInvocationHostFunction(t *testing.T) {
 				}
 
 				// We didn't ever schedule an inc for b so it should remain zero.
-				result, err = env.InvokeActor(ctx, ns, "b", "getCount", nil)
+				result, err = env.InvokeActor(ctx, ns, "b", "getCount", nil, types.CreateIfNotExist{})
 				require.NoError(t, err)
 				require.Equal(t, int64(0), getCount(t, result))
 				break
@@ -505,12 +539,12 @@ func TestScheduleInvocationHostFunction(t *testing.T) {
 func TestInvokeActorHostFunctionDeadlockRegression(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
-		_, err := reg.CreateActor(ctx, "ns-1", "a", "test-module", registry.ActorOptions{})
+		_, err := reg.CreateActor(ctx, "ns-1", "a", "test-module", types.ActorOptions{})
 		require.NoError(t, err)
-		_, err = reg.CreateActor(ctx, "ns-1", "b", "test-module", registry.ActorOptions{})
+		_, err = reg.CreateActor(ctx, "ns-1", "b", "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
-		invokeReq := wapcutils.InvokeActorRequest{
+		invokeReq := types.InvokeActorRequest{
 			ActorID:   "b",
 			Operation: "inc",
 			Payload:   nil,
@@ -518,7 +552,7 @@ func TestInvokeActorHostFunctionDeadlockRegression(t *testing.T) {
 		marshaled, err := json.Marshal(invokeReq)
 		require.NoError(t, err)
 
-		_, err = env.InvokeActor(ctx, "ns-1", "a", "invokeActor", marshaled)
+		_, err = env.InvokeActor(ctx, "ns-1", "a", "invokeActor", marshaled, types.CreateIfNotExist{})
 		require.NoError(t, err)
 	}
 
@@ -555,11 +589,11 @@ func TestHeartbeatAndSelfHealing(t *testing.T) {
 	// Create 3 different actors because we want to end up with at least one actor on each
 	// server to test the ability to "migrate" the actor's activation from one server to
 	// another.
-	_, err = reg.CreateActor(ctx, "ns-1", "a", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "ns-1", "a", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
-	_, err = reg.CreateActor(ctx, "ns-1", "b", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "ns-1", "b", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
-	_, err = reg.CreateActor(ctx, "ns-1", "c", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "ns-1", "c", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
 
 	for i := 0; i < 100; i++ {
@@ -574,29 +608,29 @@ func TestHeartbeatAndSelfHealing(t *testing.T) {
 		// Registry about the server from the server heartbeats. Therefore we need to
 		// heartbeat at least once after every actor is activated if we want to ensure the
 		// registry is able to actually load-balance the activations evenly.
-		_, err = env1.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+		_, err = env1.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
-		_, err = env2.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+		_, err = env2.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
-		_, err = env3.InvokeActor(ctx, "ns-1", "a", "inc", nil)
-		require.NoError(t, err)
-		require.NoError(t, env1.heartbeat())
-		require.NoError(t, env2.heartbeat())
-		require.NoError(t, env3.heartbeat())
-		_, err = env1.InvokeActor(ctx, "ns-1", "b", "inc", nil)
-		require.NoError(t, err)
-		_, err = env2.InvokeActor(ctx, "ns-1", "b", "inc", nil)
-		require.NoError(t, err)
-		_, err = env3.InvokeActor(ctx, "ns-1", "b", "inc", nil)
+		_, err = env3.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
 		require.NoError(t, env1.heartbeat())
 		require.NoError(t, env2.heartbeat())
 		require.NoError(t, env3.heartbeat())
-		_, err = env1.InvokeActor(ctx, "ns-1", "c", "inc", nil)
+		_, err = env1.InvokeActor(ctx, "ns-1", "b", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
-		_, err = env2.InvokeActor(ctx, "ns-1", "c", "inc", nil)
+		_, err = env2.InvokeActor(ctx, "ns-1", "b", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
-		_, err = env3.InvokeActor(ctx, "ns-1", "c", "inc", nil)
+		_, err = env3.InvokeActor(ctx, "ns-1", "b", "inc", nil, types.CreateIfNotExist{})
+		require.NoError(t, err)
+		require.NoError(t, env1.heartbeat())
+		require.NoError(t, env2.heartbeat())
+		require.NoError(t, env3.heartbeat())
+		_, err = env1.InvokeActor(ctx, "ns-1", "c", "inc", nil, types.CreateIfNotExist{})
+		require.NoError(t, err)
+		_, err = env2.InvokeActor(ctx, "ns-1", "c", "inc", nil, types.CreateIfNotExist{})
+		require.NoError(t, err)
+		_, err = env3.InvokeActor(ctx, "ns-1", "c", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
 		require.NoError(t, env1.heartbeat())
 		require.NoError(t, env2.heartbeat())
@@ -625,7 +659,7 @@ func TestHeartbeatAndSelfHealing(t *testing.T) {
 			for {
 				// Spin loop until there are no more errors as function calls will fail for
 				// a bit until heartbeat + activation cache expire.
-				_, err = env3.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+				_, err = env3.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 				if err != nil {
 					time.Sleep(100 * time.Millisecond)
 					continue
@@ -635,13 +669,13 @@ func TestHeartbeatAndSelfHealing(t *testing.T) {
 			continue
 		}
 
-		_, err = env3.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+		_, err = env3.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
 		require.NoError(t, env3.heartbeat())
-		_, err = env3.InvokeActor(ctx, "ns-1", "b", "inc", nil)
+		_, err = env3.InvokeActor(ctx, "ns-1", "b", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
 		require.NoError(t, env3.heartbeat())
-		_, err = env3.InvokeActor(ctx, "ns-1", "c", "inc", nil)
+		_, err = env3.InvokeActor(ctx, "ns-1", "c", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
 		require.NoError(t, env3.heartbeat())
 	}
@@ -660,10 +694,10 @@ func TestHeartbeatAndSelfHealing(t *testing.T) {
 func TestVersionStampIsHonored(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
-		_, err := reg.CreateActor(ctx, "ns-1", "a", "test-module", registry.ActorOptions{})
+		_, err := reg.CreateActor(ctx, "ns-1", "a", "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
-		_, err = env.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+		_, err = env.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 		require.NoError(t, err)
 
 		env.freezeHeartbeatState()
@@ -672,7 +706,7 @@ func TestVersionStampIsHonored(t *testing.T) {
 			// Eventually RPCs should start to fail because the server's versionstamp will become
 			// stale and it will no longer be confident that it's allowed to run RPCs for the
 			// actor.
-			_, err = env.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+			_, err = env.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 			if err != nil && strings.Contains(err.Error(), "server heartbeat") {
 				break
 			}
@@ -689,10 +723,10 @@ func TestVersionStampIsHonored(t *testing.T) {
 func TestCustomHostFns(t *testing.T) {
 	testFn := func(t *testing.T, reg registry.Registry, env Environment) {
 		ctx := context.Background()
-		_, err := reg.CreateActor(ctx, "ns-1", "a", "test-module", registry.ActorOptions{})
+		_, err := reg.CreateActor(ctx, "ns-1", "a", "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
-		result, err := env.InvokeActor(ctx, "ns-1", "a", "invokeCustomHostFn", []byte("testCustomFn"))
+		result, err := env.InvokeActor(ctx, "ns-1", "a", "invokeCustomHostFn", []byte("testCustomFn"), types.CreateIfNotExist{})
 		require.NoError(t, err)
 		require.Equal(t, []byte("ok"), result)
 	}
@@ -819,7 +853,7 @@ func (ta *testActor) Invoke(
 		})
 		return nil, err
 	case "invokeActor":
-		var req wapcutils.InvokeActorRequest
+		var req types.InvokeActorRequest
 		if err := json.Unmarshal(payload, &req); err != nil {
 			return nil, err
 		}
@@ -855,10 +889,10 @@ func TestServerVersionIsHonored(t *testing.T) {
 	_, err = reg.RegisterModule(ctx, "ns-1", "test-module", utilWasmBytes, registry.ModuleOptions{})
 	require.NoError(t, err)
 
-	_, err = reg.CreateActor(ctx, "ns-1", "a", "test-module", registry.ActorOptions{})
+	_, err = reg.CreateActor(ctx, "ns-1", "a", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
 
-	_, err = env1.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+	_, err = env1.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 	require.NoError(t, err)
 
 	env1.pauseHeartbeat()
@@ -869,7 +903,7 @@ func TestServerVersionIsHonored(t *testing.T) {
 
 	require.NoError(t, env1.heartbeat())
 
-	_, err = env1.InvokeActor(ctx, "ns-1", "a", "inc", nil)
+	_, err = env1.InvokeActor(ctx, "ns-1", "a", "inc", nil, types.CreateIfNotExist{})
 	require.EqualErrorf(t, err, "InvokeLocal: server version(2) != server version from reference(1)", "Error should be: %v, got: %v", "InvokeLocal: server version(1) != server version from reference(0)", err)
 }
 

--- a/virtual/host_capabilities.go
+++ b/virtual/host_capabilities.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/richardartoul/nola/virtual/registry"
+	"github.com/richardartoul/nola/virtual/types"
 	"github.com/richardartoul/nola/wapcutils"
 )
 
@@ -79,7 +80,7 @@ func (h *hostCapabilities) CreateActor(
 		req.ModuleID = h.actorModuleID
 	}
 
-	_, err := h.reg.CreateActor(ctx, h.namespace, req.ActorID, req.ModuleID, registry.ActorOptions{})
+	_, err := h.reg.CreateActor(ctx, h.namespace, req.ActorID, req.ModuleID, types.ActorOptions{})
 	if err != nil {
 		return CreateActorResult{}, err
 	}
@@ -88,9 +89,9 @@ func (h *hostCapabilities) CreateActor(
 
 func (h *hostCapabilities) InvokeActor(
 	ctx context.Context,
-	req wapcutils.InvokeActorRequest,
+	req types.InvokeActorRequest,
 ) ([]byte, error) {
-	return h.env.InvokeActor(ctx, h.namespace, req.ActorID, req.Operation, req.Payload)
+	return h.env.InvokeActor(ctx, h.namespace, req.ActorID, req.Operation, req.Payload, req.CreateIfNotExist)
 }
 
 func (h *hostCapabilities) ScheduleInvokeActor(
@@ -110,7 +111,9 @@ func (h *hostCapabilities) ScheduleInvokeActor(
 		// Copy the payload to make sure its safe to retain across invocations.
 		payloadCopy := make([]byte, len(req.Invoke.Payload))
 		copy(payloadCopy, req.Invoke.Payload)
-		_, err := h.env.InvokeActor(ctx, h.namespace, req.Invoke.ActorID, req.Invoke.Operation, payloadCopy)
+		_, err := h.env.InvokeActor(
+			ctx, h.namespace, req.Invoke.ActorID,
+			req.Invoke.Operation, req.Invoke.Payload, req.Invoke.CreateIfNotExist)
 		if err != nil {
 			log.Printf(
 				"error performing scheduled invocation from actor: %s to actor: %s for operation: %s, err: %v\n",

--- a/virtual/registry/common_test.go
+++ b/virtual/registry/common_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/richardartoul/nola/virtual/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,19 +43,19 @@ func testRegistrySimple(t *testing.T, registry Registry) {
 	require.NoError(t, err)
 
 	// Create actor fails for unknown module.
-	_, err = registry.CreateActor(ctx, "ns1", "a", "unknown-module", ActorOptions{})
+	_, err = registry.CreateActor(ctx, "ns1", "a", "unknown-module", types.ActorOptions{})
 	require.Error(t, err)
 
 	// Succeeds for known module.
-	_, err = registry.CreateActor(ctx, "ns1", "a", "test-module", ActorOptions{})
+	_, err = registry.CreateActor(ctx, "ns1", "a", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
 
 	// Fails to create duplicate actor in same namespace.
-	_, err = registry.CreateActor(ctx, "ns1", "a", "test-module", ActorOptions{})
+	_, err = registry.CreateActor(ctx, "ns1", "a", "test-module", types.ActorOptions{})
 	require.Error(t, err)
 
 	// Allows actors with same ID in different namespaces.
-	_, err = registry.CreateActor(ctx, "ns2", "a", "test-module", ActorOptions{})
+	_, err = registry.CreateActor(ctx, "ns2", "a", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
 }
 
@@ -71,12 +72,18 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	_, err := registry.RegisterModule(ctx, "ns1", "test-module", []byte("wasm"), ModuleOptions{})
 	require.NoError(t, err)
 
-	_, err = registry.CreateActor(ctx, "ns1", "a", "test-module", ActorOptions{})
+	// Should fail because the actor does not exist.
+	_, err = registry.EnsureActivation(ctx, "ns1", "a")
+	require.Error(t, err)
+	require.True(t, IsActorDoesNotExistErr(err))
+
+	_, err = registry.CreateActor(ctx, "ns1", "a", "test-module", types.ActorOptions{})
 	require.NoError(t, err)
 
 	// Should fail because there are no servers available to activate on.
 	_, err = registry.EnsureActivation(ctx, "ns1", "a")
 	require.Error(t, err)
+	require.False(t, IsActorDoesNotExistErr(err))
 
 	heartbeatResult, err := registry.Heartbeat(ctx, "server1", HeartbeatState{
 		NumActivatedActors: 10,
@@ -142,7 +149,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	// Next 10 activations should all go to server2 for balancing purposes.
 	for i := 0; i < 10; i++ {
 		actorID := fmt.Sprintf("0-%d", i)
-		_, err = registry.CreateActor(ctx, "ns1", actorID, "test-module", ActorOptions{})
+		_, err = registry.CreateActor(ctx, "ns1", actorID, "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
 		activations, err = registry.EnsureActivation(ctx, "ns1", actorID)
@@ -161,7 +168,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	var lastServerID string
 	for i := 0; i < 10; i++ {
 		actorID := fmt.Sprintf("1-%d", i)
-		_, err = registry.CreateActor(ctx, "ns1", actorID, "test-module", ActorOptions{})
+		_, err = registry.CreateActor(ctx, "ns1", actorID, "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
 		activations, err = registry.EnsureActivation(ctx, "ns1", actorID)
@@ -199,7 +206,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	// server2 because its the only one available.
 	for i := 0; i < 10; i++ {
 		actorID := fmt.Sprintf("2-%d", i)
-		_, err = registry.CreateActor(ctx, "ns1", actorID, "test-module", ActorOptions{})
+		_, err = registry.CreateActor(ctx, "ns1", actorID, "test-module", types.ActorOptions{})
 		require.NoError(t, err)
 
 		activations, err = registry.EnsureActivation(ctx, "ns1", actorID)
@@ -227,7 +234,7 @@ func testKVSimple(t *testing.T, registry Registry) {
 				// Cant start transaction for actor that doesn't exist.
 				require.Error(t, err)
 
-				_, err = registry.CreateActor(ctx, ns, actor, "test-module", ActorOptions{})
+				_, err = registry.CreateActor(ctx, ns, actor, "test-module", types.ActorOptions{})
 				require.NoError(t, err)
 
 				tr, err = registry.BeginTransaction(ctx, ns, actor, "server1", 0)

--- a/virtual/registry/common_test.go
+++ b/virtual/registry/common_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/richardartoul/nola/virtual/types"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/virtual/registry/types.go
+++ b/virtual/registry/types.go
@@ -35,7 +35,7 @@ type Registry interface {
 		namespace,
 		actorID,
 		moduleID string,
-		opts ActorOptions,
+		opts types.ActorOptions,
 	) (CreateActorResult, error)
 
 	// IncGeneration increments the actor's generation count. This is useful for ensuring
@@ -112,10 +112,6 @@ type ServiceDiscovery interface {
 		serverID string,
 		state HeartbeatState,
 	) (HeartbeatResult, error)
-}
-
-// ActorOptions contains the options for a given actor.
-type ActorOptions struct {
 }
 
 // CreateActorResult is the result of a call to CreateActor().

--- a/virtual/registry/validator.go
+++ b/virtual/registry/validator.go
@@ -71,7 +71,7 @@ func (v *validator) CreateActor(
 	namespace,
 	actorID,
 	moduleID string,
-	opts ActorOptions,
+	opts types.ActorOptions,
 ) (CreateActorResult, error) {
 	if err := validateString("namespace", namespace); err != nil {
 		return CreateActorResult{}, err

--- a/virtual/server.go
+++ b/virtual/server.go
@@ -104,7 +104,7 @@ func (s *server) createActor(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cc()
-	result, err := s.registry.CreateActor(ctx, req.Namespace, req.ActorID, req.ModuleID, registry.ActorOptions{})
+	result, err := s.registry.CreateActor(ctx, req.Namespace, req.ActorID, req.ModuleID, types.ActorOptions{})
 	if err != nil {
 		w.WriteHeader(500)
 		w.Write([]byte(err.Error()))
@@ -125,11 +125,9 @@ func (s *server) createActor(w http.ResponseWriter, r *http.Request) {
 type invokeActorRequest struct {
 	ServerID  string `json:"server_id"`
 	Namespace string `json:"namespace"`
-	ActorID   string `json:"actor_id"`
-	Operation string `json:"operation"`
-	Payload   []byte `json:"payload"`
-	// Same data as Payload, but different field so it doesn't have to be encoded
-	// as base64.
+	types.InvokeActorRequest
+	// Same data as Payload (in types.InvokeActorRequest), but different field so it doesn't
+	// have to be encoded as base64.
 	PayloadJSON interface{} `json:"payload_json"`
 }
 
@@ -161,7 +159,8 @@ func (s *server) invoke(w http.ResponseWriter, r *http.Request) {
 	// TODO: This should be configurable, probably in a header with some maximum.
 	ctx, cc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cc()
-	result, err := s.environment.InvokeActor(ctx, req.Namespace, req.ActorID, req.Operation, req.Payload)
+	result, err := s.environment.InvokeActor(
+		ctx, req.Namespace, req.ActorID, req.Operation, req.Payload, req.CreateIfNotExist)
 	if err != nil {
 		w.WriteHeader(500)
 		w.Write([]byte(err.Error()))

--- a/virtual/types.go
+++ b/virtual/types.go
@@ -24,6 +24,7 @@ type Environment interface {
 		actorID string,
 		operation string,
 		payload []byte,
+		createIfNotExist types.CreateIfNotExist,
 	) ([]byte, error)
 
 	// InvokeActorDirect is the same as InvokeActor, however, it performs the invocation
@@ -137,7 +138,7 @@ type HostCapabilities interface {
 	CreateActor(context.Context, wapcutils.CreateActorRequest) (CreateActorResult, error)
 
 	// InvokeActor invokes a function on the specified actor.
-	InvokeActor(context.Context, wapcutils.InvokeActorRequest) ([]byte, error)
+	InvokeActor(context.Context, types.InvokeActorRequest) ([]byte, error)
 
 	// ScheduleInvokeActor is the same as InvokeActor, except the invocation is scheduled
 	// in memory to be run later.

--- a/virtual/types/req.go
+++ b/virtual/types/req.go
@@ -1,0 +1,28 @@
+package types
+
+// InvokeActorRequest is the JSON struct that represents a request from an existing
+// actor to invoke an operation on another one.
+type InvokeActorRequest struct {
+	// ActorID is the ID of the target actor. Omit when being used inside of
+	// ScheduleInvocationRequest to target self.
+	ActorID string `json:"actor_id"`
+	// Operation is the name of the operation to invoke on the target actor.
+	Operation string `json:"operation"`
+	// Payload is the []byte payload to provide to the invoked function on the
+	// target actor.
+	Payload []byte `json:"payload"`
+	// CreateIfNotExist provides the arguments for InvokeActorRequest to construct the
+	// actor if it doesn't already exist. This field is optional.
+	CreateIfNotExist CreateIfNotExist `json:"create_if_not_exist"`
+}
+
+// CreateIfNotExist provides the arguments for InvokeActorRequest to construct the
+// actor if it doesn't already exist.
+type CreateIfNotExist struct {
+	ModuleID string       `json:"module_id"`
+	Options  ActorOptions `json:"actor_options"`
+}
+
+// ActorOptions contains the options for a given actor.
+type ActorOptions struct {
+}

--- a/wapcutils/actor.go
+++ b/wapcutils/actor.go
@@ -1,5 +1,7 @@
 package wapcutils
 
+import "github.com/richardartoul/nola/virtual/types"
+
 // CreateActorRequest is the JSON struct that represents a request from an existing
 // actor to create a new one.
 type CreateActorRequest struct {
@@ -12,23 +14,10 @@ type CreateActorRequest struct {
 	ModuleID string `json:"module_id"`
 }
 
-// InvokeActorRequest is the JSON struct that represents a request from an existing
-// actor to invoke an operation on another one.
-type InvokeActorRequest struct {
-	// ActorID is the ID of the target actor. Omit when being used inside of
-	// ScheduleInvocationRequest to target self.
-	ActorID string `json:"actor_id"`
-	// Operation is the name of the operation to invoke on the target actor.
-	Operation string `json:"operation"`
-	// Payload is the []byte payload to provide to the invoked function on the
-	// target actor.
-	Payload []byte `json:"payload"`
-}
-
 // ScheduleInvocationRequest is the JSON struct that represents a request from an
 // existing actor to invoke an operation on another one (or its self) at a later
 // time.
 type ScheduleInvocationRequest struct {
-	Invoke      InvokeActorRequest `json:"invocation"`
-	AfterMillis int                `json:"after_millis"`
+	Invoke      types.InvokeActorRequest `json:"invocation"`
+	AfterMillis int                      `json:"after_millis"`
 }


### PR DESCRIPTION
This dramatically simplifies implementation some application that require "per tenant" actors the number of which is not known ahead of time or application which depend heavily on dynamic sharding. Closes #8 