### PR TITLE
Basic CI to run unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Install foundationdb
+      uses: pyr/foundationdb-actions-install@2b2c6dee7f3e21864c060c5fd53838e2e8a28aa1
+      with:
+        version: "7.1.27"
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+
+    - name: Format
+      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/richardartoul/nola
 
+// Update in GH Actions too
 go 1.19
 
 require (


### PR DESCRIPTION
This PR adds a simple Github action to run all of the go test and makes sure it still builds. Tested here: https://github.com/griffin/nola/actions/runs/4093339939/jobs/7058707972

I can create issues to add support for a FDB service container as a ticket. Planning on adding a service container for PG in https://github.com/richardartoul/nola/pull/36