### PR TITLE
Quality of life improvements to make writing apps + tests easier

### DIFF
--- a/examples/dnsregistry/main.go
+++ b/examples/dnsregistry/main.go
@@ -28,8 +28,7 @@ func main() {
 		log.Fatalf("host cannot be empty")
 	}
 
-	registry, err := dnsregistry.NewDNSRegistry(
-		dnsregistry.NewDNSResolver(), *host, *port, dnsregistry.DNSRegistryOptions{})
+	registry, err := dnsregistry.NewDNSRegistry(*host, *port, dnsregistry.DNSRegistryOptions{})
 	if err != nil {
 		log.Fatalf(
 			"error creating DNS registry: %v, make sure /etc/hosts contains an entry for host: %s",
@@ -44,12 +43,16 @@ func main() {
 				DiscoveryType: virtual.DiscoveryTypeRemote,
 				Port:          *port,
 			},
-			GoModules: map[types.NamespacedIDNoType]virtual.Module{
-				types.NewNamespacedIDNoType("example", "test-module"): &testModule{},
-			},
 		})
 	if err != nil {
 		log.Fatalf("error creating virtual environment: %v", err)
+	}
+
+	err = env.RegisterGoModule(
+		types.NewNamespacedIDNoType("example", "test-module"),
+		&testModule{})
+	if err != nil {
+		log.Fatalf("error registering Go module with virtual environment: %v", err)
 	}
 
 	go func() {

--- a/examples/dnsregistry/main.go
+++ b/examples/dnsregistry/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/richardartoul/nola/virtual"
 	"github.com/richardartoul/nola/virtual/registry"
-	"github.com/richardartoul/nola/virtual/registry/dnsregistry"
 	"github.com/richardartoul/nola/virtual/types"
 	"github.com/richardartoul/nola/wapcutils"
 )
@@ -28,22 +27,8 @@ func main() {
 		log.Fatalf("host cannot be empty")
 	}
 
-	registry, err := dnsregistry.NewDNSRegistry(*host, *port, dnsregistry.DNSRegistryOptions{})
-	if err != nil {
-		log.Fatalf(
-			"error creating DNS registry: %v, make sure /etc/hosts contains an entry for host: %s",
-			err, *host)
-	}
-
-	env, err := virtual.NewEnvironment(
-		context.Background(),
-		dnsregistry.DNSServerID, registry,
-		virtual.NewHTTPClient(), virtual.EnvironmentOptions{
-			Discovery: virtual.DiscoveryOptions{
-				DiscoveryType: virtual.DiscoveryTypeRemote,
-				Port:          *port,
-			},
-		})
+	env, registry, err := virtual.NewDNSRegistryEnvironment(
+		context.Background(), *host, *port, virtual.EnvironmentOptions{})
 	if err != nil {
 		log.Fatalf("error creating virtual environment: %v", err)
 	}

--- a/examples/file_cache/benchmark_test.go
+++ b/examples/file_cache/benchmark_test.go
@@ -48,13 +48,14 @@ func TestFileCacheBenchmark(t *testing.T) {
 			// Make sure the benchmark tests the RPC/HTTP stack, not just the
 			// in-memory virtual.Environment code.
 			ForceRemoteProcedureCalls: true,
-			GoModules: map[types.NamespacedIDNoType]virtual.Module{
-				types.NewNamespacedIDNoType("bench-ns", "file-cache"): NewFileCacheModule(chunkSize, fetchSize, fetcher, cache),
-			},
 		})
 	if err != nil {
 		log.Fatalf("error creating virtual environment: %v", err)
 	}
+	err = env.RegisterGoModule(
+		types.NewNamespacedIDNoType("bench-ns", "file-cache"),
+		NewFileCacheModule(chunkSize, fetchSize, fetcher, cache))
+	require.NoError(t, err)
 
 	server := virtual.NewServer(registry, env)
 	go func() {

--- a/examples/file_cache/file_cache_test.go
+++ b/examples/file_cache/file_cache_test.go
@@ -40,7 +40,6 @@ func testFileCacheActorConcurrency(t *testing.T, injectFaults bool) {
 	fileCache, err := NewFileCacheActor(fileSize, chunkSize, fetchSize, fetcher, cache)
 	require.NoError(t, err)
 
-	fmt.Println(string(fetcher.(*testFetcher).file))
 	var (
 		numWorkers      = runtime.NumCPU()
 		numOpsPerWorker = 100_000

--- a/virtual/activations.go
+++ b/virtual/activations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/richardartoul/nola/virtual/registry"
 	"github.com/richardartoul/nola/virtual/types"
 	"github.com/richardartoul/nola/wapcutils"
+
 	"github.com/wapc/wapc-go/engines/wazero"
 )
 

--- a/virtual/activations.go
+++ b/virtual/activations.go
@@ -37,7 +37,6 @@ type activations struct {
 func newActivations(
 	registry registry.Registry,
 	environment Environment,
-	goModules map[types.NamespacedIDNoType]Module,
 	customHostFns map[string]func([]byte) ([]byte, error),
 ) *activations {
 	return &activations{
@@ -46,9 +45,19 @@ func newActivations(
 
 		registry:      registry,
 		environment:   environment,
-		goModules:     goModules,
+		goModules:     make(map[types.NamespacedIDNoType]Module),
 		customHostFns: customHostFns,
 	}
+}
+
+func (a *activations) registerGoModule(id types.NamespacedIDNoType, module Module) error {
+	a.Lock()
+	defer a.Unlock()
+	if _, ok := a.goModules[id]; ok {
+		return fmt.Errorf("error registering go module with ID: %v, already registered", id)
+	}
+	a.goModules[id] = module
+	return nil
 }
 
 // invoke has a lot of manual locking and unlocking. While error prone, this is intentional

--- a/virtual/environment.go
+++ b/virtual/environment.go
@@ -125,7 +125,7 @@ func NewTestDNSRegistryEnvironment(
 	ctx context.Context,
 	opts EnvironmentOptions,
 ) (Environment, registry.Registry, error) {
-	return NewDNSRegistryEnvironment(ctx, Localhost, 9093, EnvironmentOptions{})
+	return NewDNSRegistryEnvironment(ctx, Localhost, 9093, opts)
 }
 
 // DiscoveryOptions contains the discovery-related options.

--- a/virtual/environment.go
+++ b/virtual/environment.go
@@ -83,7 +83,12 @@ type EnvironmentOptions struct {
 	CustomHostFns map[string]func([]byte) ([]byte, error)
 }
 
-// func NewDNSRegistryEnvironment(host string, port int)
+func NewDNSRegistryEnvironment(host string, port int, opts EnvironmentOptions) {
+	// TODO: Implement me as a one lien function that can be used in simple scenarios.
+
+	// TODO: Another function like this, but with no arguments. Can just call it like
+	// NewTestEnvironment or something.
+}
 
 // DiscoveryOptions contains the discovery-related options.
 type DiscoveryOptions struct {

--- a/virtual/environment.go
+++ b/virtual/environment.go
@@ -83,7 +83,11 @@ type EnvironmentOptions struct {
 	CustomHostFns map[string]func([]byte) ([]byte, error)
 }
 
-// TODO: Comment me.
+// NewDNSRegistryEnvironment is a convenience function that creates a virtual environment backed
+// by a DNS-based registry. It is configured with reasonable defaults that make it suitable for
+// production usage. Note that this convenience function is particularly nice because it can also
+// be used for unit/integration tests and local development simply by passing virtual.Localhost
+// as the value of host.
 func NewDNSRegistryEnvironment(
 	ctx context.Context,
 	host string,
@@ -114,7 +118,9 @@ func NewDNSRegistryEnvironment(
 	return env, reg, nil
 }
 
-// TODO: Comment me.
+// NewTestDNSRegistryEnvironment is a convenience function that creates a virtual environment
+// backed by a DNS-based registry. It is configured already to generate a suitable setting up
+// for writing unit/integration tests, but not for production usage.
 func NewTestDNSRegistryEnvironment(
 	ctx context.Context,
 	opts EnvironmentOptions,

--- a/virtual/environment.go
+++ b/virtual/environment.go
@@ -19,6 +19,8 @@ import (
 )
 
 const (
+	Localhost = "127.0.0.1"
+
 	heartbeatTimeout           = registry.HeartbeatTTL
 	defaultActivationsCacheTTL = heartbeatTimeout
 	maxNumActivationsToCache   = 1e6 // 1 Million.
@@ -138,7 +140,7 @@ func NewEnvironment(
 		return nil, fmt.Errorf("error creating activationCache: %w", err)
 	}
 
-	host := "127.0.0.1"
+	host := Localhost
 	if opts.Discovery.DiscoveryType == DiscoveryTypeRemote {
 		selfIP, err := getSelfIP()
 		if err != nil {
@@ -514,6 +516,12 @@ func (r *environment) invokeReferences(
 		localEnv, ok := localEnvironmentsRouter[ref.Address()]
 		localEnvironmentsRouterLock.RUnlock()
 		if ok {
+			return localEnv.InvokeActorDirectStream(
+				ctx, versionStamp, ref.ServerID(), ref.ServerVersion(), ref,
+				operation, payload, create)
+		}
+
+		if ref.Address() == Localhost || ref.Address() == dnsregistry.Localhost {
 			return localEnv.InvokeActorDirectStream(
 				ctx, versionStamp, ref.ServerID(), ref.ServerVersion(), ref,
 				operation, payload, create)

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -25,37 +25,30 @@ import (
 var (
 	streamInterfaceWasCalledMutex sync.Mutex
 	streamInterfaceWasCalled      = false
+	customHostFns                 = map[string]func([]byte) ([]byte, error){
+		"testCustomFn": func([]byte) ([]byte, error) {
+			return []byte("ok"), nil
+		},
+	}
 
 	utilWasmBytes   []byte
 	defaultOptsWASM = EnvironmentOptions{
 		Discovery: DiscoveryOptions{
 			DiscoveryType: DiscoveryTypeLocalHost,
 		},
-		CustomHostFns: map[string]func([]byte) ([]byte, error){
-			"testCustomFn": func([]byte) ([]byte, error) {
-				return []byte("ok"), nil
-			},
-		},
+		CustomHostFns: customHostFns,
 	}
 	defaultOptsGoByte = EnvironmentOptions{
 		Discovery: DiscoveryOptions{
 			DiscoveryType: DiscoveryTypeLocalHost,
 		},
-		CustomHostFns: map[string]func([]byte) ([]byte, error){
-			"testCustomFn": func([]byte) ([]byte, error) {
-				return []byte("ok"), nil
-			},
-		},
+		CustomHostFns: customHostFns,
 	}
 	defaultOptsGoStream = EnvironmentOptions{
 		Discovery: DiscoveryOptions{
 			DiscoveryType: DiscoveryTypeLocalHost,
 		},
-		CustomHostFns: map[string]func([]byte) ([]byte, error){
-			"testCustomFn": func([]byte) ([]byte, error) {
-				return []byte("ok"), nil
-			},
-		},
+		CustomHostFns: customHostFns,
 	}
 )
 
@@ -838,7 +831,9 @@ func runWithDifferentConfigs(
 
 	if !skipDNS {
 		t.Run("go-dns", func(t *testing.T) {
-			env, reg, err := NewTestDNSRegistryEnvironment(context.Background(), EnvironmentOptions{})
+			env, reg, err := NewTestDNSRegistryEnvironment(context.Background(), EnvironmentOptions{
+				CustomHostFns: customHostFns,
+			})
 			require.NoError(t, err)
 			defer env.Close()
 

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/richardartoul/nola/virtual/registry"
-	"github.com/richardartoul/nola/virtual/registry/dnsregistry"
 	"github.com/richardartoul/nola/virtual/registry/localregistry"
 	"github.com/richardartoul/nola/virtual/types"
 	"github.com/richardartoul/nola/wapcutils"
@@ -839,10 +838,7 @@ func runWithDifferentConfigs(
 
 	if !skipDNS {
 		t.Run("go-dns", func(t *testing.T) {
-			reg, err := dnsregistry.NewDNSRegistry(dnsregistry.Localhost, defaultOptsGoByte.Discovery.Port, dnsregistry.DNSRegistryOptions{})
-			require.NoError(t, err)
-
-			env, err := NewEnvironment(context.Background(), "serverID1", reg, nil, defaultOptsGoByte)
+			env, reg, err := NewTestDNSRegistryEnvironment(context.Background(), EnvironmentOptions{})
 			require.NoError(t, err)
 			defer env.Close()
 

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -838,10 +838,7 @@ func runWithDifferentConfigs(
 
 	if !skipDNS {
 		t.Run("go-dns", func(t *testing.T) {
-			resolver := &fakeResolver{}
-			resolver.setIPs([]net.IP{net.ParseIP("127.0.0.1")})
-
-			reg, err := dnsregistry.NewDNSRegistry(resolver, "test", defaultOptsGoByte.Discovery.Port, dnsregistry.DNSRegistryOptions{})
+			reg, err := dnsregistry.NewDNSRegistry(dnsregistry.Localhost, defaultOptsGoByte.Discovery.Port, dnsregistry.DNSRegistryOptions{})
 			require.NoError(t, err)
 
 			env, err := NewEnvironment(context.Background(), "serverID1", reg, nil, defaultOptsGoByte)

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -826,7 +826,7 @@ func runWithDifferentConfigs(
 		env.RegisterGoModule(
 			types.NamespacedIDNoType{Namespace: "ns-1", ID: "test-module"}, testStreamModule{})
 		env.RegisterGoModule(
-			types.NamespacedIDNoType{Namespace: "ns-2x", ID: "test-module"}, testStreamModule{})
+			types.NamespacedIDNoType{Namespace: "ns-2", ID: "test-module"}, testStreamModule{})
 
 		testFn(t, reg, env)
 
@@ -849,7 +849,7 @@ func runWithDifferentConfigs(
 			env.RegisterGoModule(
 				types.NamespacedIDNoType{Namespace: "ns-1", ID: "test-module"}, testStreamModule{})
 			env.RegisterGoModule(
-				types.NamespacedIDNoType{Namespace: "ns-2x", ID: "test-module"}, testStreamModule{})
+				types.NamespacedIDNoType{Namespace: "ns-2", ID: "test-module"}, testStreamModule{})
 
 			testFn(t, reg, env)
 		})

--- a/virtual/types.go
+++ b/virtual/types.go
@@ -15,6 +15,10 @@ import (
 type Environment interface {
 	debug
 
+	// RegisterGoModule registers a new Go module in the environment so it can be used in
+	// subsequent calls.
+	RegisterGoModule(id types.NamespacedIDNoType, module Module) error
+
 	// InvokeActor invokes the specified operation on the specified actorID with the
 	// provided payload. If the actor is already activated somewhere in the system,
 	// the invocation will be routed appropriately. Otherwise, the request will

--- a/virtual/types.go
+++ b/virtual/types.go
@@ -16,7 +16,13 @@ type Environment interface {
 	debug
 
 	// RegisterGoModule registers a new Go module in the environment so it can be used in
-	// subsequent calls.
+	// subsequent calls. RegisterGoModule can be called at any time, even once the
+	// Environmnt has been in use for a long time. However, the primary reason this method
+	// exists (instead of being an argument provided to the Environment constructor) is
+	// so that applications can write many different packages that all accept an instance
+	// of Environment as a dependency and "register" whatever Go modules they need without
+	// having to register all the Go modules for all the different packages in a single
+	// place.
 	RegisterGoModule(id types.NamespacedIDNoType, module Module) error
 
 	// InvokeActor invokes the specified operation on the specified actorID with the


### PR DESCRIPTION
This P.R includes a variety of quality of life improvements that make it easier to use NOLA in tests and actual applications with minimal differences between production configuration and test configuration.

Specifically it:

1. Add some convenience functions for instantiating DNS-backed virtual environment in the virtual package.
2. Makes it possible to register Go modules with the virtual environment at any time (via a method call) instead of just when the virtual environment is created which makes sharing a single virtual environment among many different packages in an application much easier.
3. Ensures that if environments/dnsregistry are created with "localhost" as the hostname some magic stuff happens to make everything "just work" in a single node / unit test setup.