### PR TITLE
Refactor activations.go

### DIFF
--- a/cmd/app/benchmarks/benchmarks_test.go
+++ b/cmd/app/benchmarks/benchmarks_test.go
@@ -22,6 +22,9 @@ import (
 var (
 	utilWasmBytes   []byte
 	defaultOptsWASM = virtual.EnvironmentOptions{
+		Discovery: virtual.DiscoveryOptions{
+			DiscoveryType: virtual.DiscoveryTypeLocalHost,
+		},
 		CustomHostFns: map[string]func([]byte) ([]byte, error){
 			"testCustomFn": func([]byte) ([]byte, error) {
 				return []byte("ok"), nil

--- a/virtual/activations.go
+++ b/virtual/activations.go
@@ -368,7 +368,7 @@ func (a *activatedActor) close(ctx context.Context) error {
 	_, err := a.invoke(ctx, wapcutils.ShutdownOperationName, nil)
 	if err != nil {
 		log.Printf(
-			"error invoking shutdown operation for actor: %v during close: %w",
+			"error invoking shutdown operation for actor: %v during close: %v",
 			a.reference, err)
 	}
 

--- a/virtual/activations.go
+++ b/virtual/activations.go
@@ -78,7 +78,7 @@ func (a *activations) invoke(
 	instantiatePayload []byte,
 	invokePayload []byte,
 ) (io.ReadCloser, error) {
-	// First check if the actor is alread activated.
+	// First check if the actor is already activated.
 	a.Lock()
 	actorF, ok := a._actors[reference.ActorID()]
 	if !ok {
@@ -157,7 +157,8 @@ func (a *activations) invokeNotExistWithLock(
 	a._actors[reference.ActorID()] = fut
 	a.Unlock()
 
-	fut.Go(func() (actor *activatedActor, err error) {
+	// GoSync since this goroutine needs to wait anyways.
+	fut.GoSync(func() (actor *activatedActor, err error) {
 		if prevActor != nil {
 			if err := prevActor.close(ctx); err != nil {
 				log.Printf(

--- a/virtual/activations.go
+++ b/virtual/activations.go
@@ -27,8 +27,7 @@ type activations struct {
 	_modules           map[types.NamespacedID]Module
 	_actors            map[types.NamespacedActorID]futures.Future[*activatedActor]
 	moduleFetchDeduper singleflight.Group
-	// activationDeduper  singleflight.Group
-	serverState struct {
+	serverState        struct {
 		sync.RWMutex
 		serverID      string
 		serverVersion int64
@@ -335,7 +334,6 @@ type activatedActor struct {
 	reference types.ActorReferenceVirtual
 	host      HostCapabilities
 	closed    bool
-	// shutdownTimer *time.Timer
 }
 
 func newActivatedActor(
@@ -350,11 +348,6 @@ func newActivatedActor(
 		reference: reference,
 		host:      host,
 	}
-	// time.AfterFunc(time.Minute, func() {
-	// 	if err := a.close(context.TODO()); err != nil {
-	// 		log.Printf("error closing actor: %v due to inactivity: %w", reference, err)
-	// 	}
-	// })
 
 	_, err := a.invoke(ctx, wapcutils.StartupOperationName, instantiatePayload, false)
 	if err != nil {

--- a/virtual/futures/futures.go
+++ b/virtual/futures/futures.go
@@ -21,8 +21,14 @@ func New[T any]() Future[T] {
 	return f
 }
 
-func (f *future[T]) Go(fn func() (T, error)) {
+func (f *future[T]) GoSync(fn func() (T, error)) {
 	f.ResolveOrReject(fn())
+}
+
+func (f *future[T]) GoAsync(fn func() (T, error)) {
+	go func() {
+		f.ResolveOrReject(fn())
+	}()
 }
 
 func (f *future[T]) Resolve(result T) {

--- a/virtual/futures/futures.go
+++ b/virtual/futures/futures.go
@@ -1,0 +1,106 @@
+package futures
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type future[T any] struct {
+	sync.Mutex
+	sync.WaitGroup
+
+	result   T
+	err      error
+	resolved bool
+}
+
+func New[T any]() Future[T] {
+	f := &future[T]{}
+	f.Add(1)
+	return f
+}
+
+func (f *future[T]) Go(fn func() (T, error)) {
+	f.ResolveOrReject(fn())
+}
+
+func (f *future[T]) Resolve(result T) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.resolved {
+		panic("future resolved multiple times")
+	}
+
+	f.resolved = true
+	f.result = result
+	f.WaitGroup.Done()
+}
+
+func (f *future[T]) Reject(err error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.resolved {
+		panic("future resolved multiple times")
+	}
+
+	f.resolved = true
+	f.err = err
+	f.WaitGroup.Done()
+}
+
+func (f *future[T]) ResolveOrReject(result T, err error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.resolved {
+		panic("future resolved multiple times")
+	}
+
+	f.resolved = true
+	f.result = result
+	f.err = err
+	f.WaitGroup.Done()
+}
+
+func (f *future[T]) Wait() (result T, err error) {
+	f.WaitGroup.Wait()
+	return f.result, f.err
+}
+
+func WaitAllSlice[T any](futures []Future[T]) ([]T, error) {
+	results := make([]T, 0, len(futures))
+	for i, fut := range futures {
+		result, err := fut.Wait()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"WaitAllSlice: future at index: %d resolved with error: %w",
+				i, err)
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+func WaitAllSliceCtx[T any](ctx context.Context, futures []Future[T]) ([]T, error) {
+	waitCh := make(chan resultsOrErr[T])
+	go func() {
+		results, err := WaitAllSlice(futures)
+		waitCh <- resultsOrErr[T]{results, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case r := <-waitCh:
+		return r.results, r.err
+	}
+}
+
+type resultsOrErr[T any] struct {
+	results []T
+	err     error
+}

--- a/virtual/futures/types.go
+++ b/virtual/futures/types.go
@@ -1,9 +1,22 @@
 package futures
 
+// Future is the interface for a Future. It behaves similarly to a Promise
+// or Future in other programming languages.
 type Future[T any] interface {
-	Go(func() (T, error))
+	// GoSync executes the provided function in the current Goroutine and
+	// resolves the future with the return result.
+	GoSync(func() (T, error))
+	// GoAsync is the same as GoSync, but it runs the function in a new
+	// goroutine and doesn't block the caller.
+	GoAsync(func() (T, error))
+	// Resolve resolves the future immediately with result.
 	Resolve(result T)
+	// Reject rejects the future immediately with an error.
 	Reject(err error)
+	// ResolveOrReject combines Resolve and Reject into one method for
+	// convenience.
 	ResolveOrReject(result T, err error)
+	// Wait waits for the future to resolve and returns the tuple of
+	// result/error.
 	Wait() (result T, err error)
 }

--- a/virtual/futures/types.go
+++ b/virtual/futures/types.go
@@ -1,0 +1,9 @@
+package futures
+
+type Future[T any] interface {
+	Go(func() (T, error))
+	Resolve(result T)
+	Reject(err error)
+	ResolveOrReject(result T, err error)
+	Wait() (result T, err error)
+}


### PR DESCRIPTION
Refactor activations.go to:
1. Simplify code
2. Make it easier to support actor expiration
3. Deduplicate module loads
4. Prevent lock contention by avoiding holding global lock during per-actor initialization/shutdown phase.