### PR TITLE
Improve error handling with streaming API

### DIFF
--- a/virtual/server.go
+++ b/virtual/server.go
@@ -155,16 +155,8 @@ func (s *Server) invoke(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(err.Error()))
 		return
 	}
-	defer result.Close()
 
-	w.WriteHeader(200)
-	if _, err := io.Copy(w, result); err != nil {
-		// If we get any error copying the stream into the response then we
-		// need to terminate the connection to ensure that the caller observes
-		// an error and not a truncated response (that appears successful because
-		// of the 200 status code).
-		terminateConnection(w)
-	}
+	copyResultIntoStreamAndCloseResult(w, result)
 }
 
 type invokeActorDirectRequest struct {
@@ -219,42 +211,8 @@ func (s *Server) invokeDirect(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(err.Error()))
 		return
 	}
-	defer result.Close()
 
-	// Try reading 1 byte first to improve the probability we can return a readable
-	// error to the user.
-	var buf [1]byte
-	n, err := result.Read(buf[:])
-	if err != nil {
-		writeStatusCodeForError(w, err)
-		w.Write([]byte(err.Error()))
-		return
-	}
-	if n != 1 {
-		writeStatusCodeForError(w, err)
-		w.Write([]byte(fmt.Sprintf(
-			"expected to read 1 byte, but read: %d", n)))
-		return
-	}
-
-	// Ok we managed to read at least 1 byte so lets send the 200 status code and
-	// start streaming the response.
-	w.WriteHeader(200)
-
-	// Don't forget to copy the byte we already read.
-	if n, err := w.Write(buf[:]); n != 1 || err != nil {
-		// If we get any error copying the stream into the response then we
-		// need to terminate the connection to ensure that the caller observes
-		// an error and not a truncated response (that appears successful because
-		// of the 200 status code).
-		terminateConnection(w)
-		return
-	}
-
-	if _, err := io.Copy(w, result); err != nil {
-		// Same comment as above.
-		terminateConnection(w)
-	}
+	copyResultIntoStreamAndCloseResult(w, result)
 }
 
 type invokeWorkerRequest struct {
@@ -298,16 +256,8 @@ func (s *Server) invokeWorker(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(err.Error()))
 		return
 	}
-	defer result.Close()
 
-	w.WriteHeader(200)
-	if _, err := io.Copy(w, result); err != nil {
-		// If we get any error copying the stream into the response then we
-		// need to terminate the connection to ensure that the caller observes
-		// an error and not a truncated response (that appears successful because
-		// of the 200 status code).
-		terminateConnection(w)
-	}
+	copyResultIntoStreamAndCloseResult(w, result)
 }
 
 // ensureHijackable and terminateConnection are used in conjunction to close tcp connections
@@ -339,5 +289,47 @@ func writeStatusCodeForError(w http.ResponseWriter, err error) {
 		w.WriteHeader(httpErr.HTTPStatusCode())
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func copyResultIntoStreamAndCloseResult(
+	w http.ResponseWriter,
+	result io.ReadCloser,
+) {
+	defer result.Close()
+
+	// Try reading 1 byte first to improve the probability we can return a readable
+	// error to the user.
+	var buf [1]byte
+	n, err := result.Read(buf[:])
+	if err != nil {
+		writeStatusCodeForError(w, err)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	if n != 1 {
+		writeStatusCodeForError(w, err)
+		w.Write([]byte(fmt.Sprintf(
+			"expected to read 1 byte, but read: %d", n)))
+		return
+	}
+
+	// Ok we managed to read at least 1 byte so lets send the 200 status code and
+	// start streaming the response.
+	w.WriteHeader(200)
+
+	// Don't forget to copy the byte we already read.
+	if n, err := w.Write(buf[:]); n != 1 || err != nil {
+		// If we get any error copying the stream into the response then we
+		// need to terminate the connection to ensure that the caller observes
+		// an error and not a truncated response (that appears successful because
+		// of the 200 status code).
+		terminateConnection(w)
+		return
+	}
+
+	if _, err := io.Copy(w, result); err != nil {
+		// Same comment as above.
+		terminateConnection(w)
 	}
 }

--- a/virtual/server.go
+++ b/virtual/server.go
@@ -221,12 +221,38 @@ func (s *Server) invokeDirect(w http.ResponseWriter, r *http.Request) {
 	}
 	defer result.Close()
 
+	// Try reading 1 byte first to improve the probability we can return a readable
+	// error to the user.
+	var buf [1]byte
+	n, err := result.Read(buf[:])
+	if err != nil {
+		writeStatusCodeForError(w, err)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	if n != 1 {
+		writeStatusCodeForError(w, err)
+		w.Write([]byte(fmt.Sprintf(
+			"expected to read 1 byte, but read: %d", n)))
+		return
+	}
+
+	// Ok we managed to read at least 1 byte so lets send the 200 status code and
+	// start streaming the response.
 	w.WriteHeader(200)
-	if _, err := io.Copy(w, result); err != nil {
+
+	// Don't forget to copy the byte we already read.
+	if n, err := w.Write(buf[:]); n != 1 || err != nil {
 		// If we get any error copying the stream into the response then we
 		// need to terminate the connection to ensure that the caller observes
 		// an error and not a truncated response (that appears successful because
 		// of the 200 status code).
+		terminateConnection(w)
+		return
+	}
+
+	if _, err := io.Copy(w, result); err != nil {
+		// Same comment as above.
 		terminateConnection(w)
 	}
 }

--- a/virtual/server.go
+++ b/virtual/server.go
@@ -302,6 +302,10 @@ func copyResultIntoStreamAndCloseResult(
 	// error to the user.
 	var buf [1]byte
 	n, err := result.Read(buf[:])
+	if err == io.EOF {
+		// Special case handle for valid (but empty) streams.
+		return
+	}
 	if err != nil {
 		writeStatusCodeForError(w, err)
 		w.Write([]byte(err.Error()))


### PR DESCRIPTION
This makes it much more likely that the caller will see a reasonable error when an one occurs with the streaming APIs.