### PR TITLE
Fix bug causing stale cache entries

### DIFF
--- a/cmd/app/benchmarks/benchmarks_test.go
+++ b/cmd/app/benchmarks/benchmarks_test.go
@@ -42,17 +42,17 @@ func init() {
 }
 
 func BenchmarkLocalInvokeActor(b *testing.B) {
-	reg := localregistry.NewLocalRegistry()
+	reg := localregistry.NewLocalRegistry("test-server-id")
 	benchmarkInvokeActor(b, reg)
 }
 
 func BenchmarkLocalInvokeWorker(b *testing.B) {
-	reg := localregistry.NewLocalRegistry()
+	reg := localregistry.NewLocalRegistry("test-server-id")
 	benchmarkInvokeWorker(b, reg)
 }
 
 func BenchmarkFoundationDBRegistryInvokeActor(b *testing.B) {
-	reg, err := fdbregistry.NewFoundationDBRegistry("")
+	reg, err := fdbregistry.NewFoundationDBRegistry("test-server-id", "")
 	require.NoError(b, err)
 	require.NoError(b, reg.UnsafeWipeAll())
 
@@ -60,7 +60,7 @@ func BenchmarkFoundationDBRegistryInvokeActor(b *testing.B) {
 }
 
 func BenchmarkFoundationDBRegistryInvokeWorker(b *testing.B) {
-	reg, err := fdbregistry.NewFoundationDBRegistry("")
+	reg, err := fdbregistry.NewFoundationDBRegistry("test-server-id", "")
 	require.NoError(b, err)
 	require.NoError(b, reg.UnsafeWipeAll())
 
@@ -117,7 +117,7 @@ func benchmarkInvokeWorker(b *testing.B, reg registry.Registry) {
 
 func BenchmarkLocalCreateThenInvokeActor(b *testing.B) {
 	var (
-		reg         = localregistry.NewLocalRegistry()
+		reg         = localregistry.NewLocalRegistry("test-server-id")
 		moduleStore = reg.(registry.ModuleStore)
 	)
 	env, err := virtual.NewEnvironment(
@@ -143,7 +143,7 @@ func BenchmarkLocalCreateThenInvokeActor(b *testing.B) {
 
 func BenchmarkLocalActorToActorCommunication(b *testing.B) {
 	var (
-		reg         = localregistry.NewLocalRegistry()
+		reg         = localregistry.NewLocalRegistry("test-server-id")
 		moduleStore = reg.(registry.ModuleStore)
 	)
 	env, err := virtual.NewEnvironment(
@@ -202,7 +202,7 @@ func testSimpleBench(
 	// Uncomment to run.
 	t.Skip()
 
-	reg, err := fdbregistry.NewFoundationDBRegistry("")
+	reg, err := fdbregistry.NewFoundationDBRegistry("test-server-id", "")
 	require.NoError(t, err)
 	require.NoError(t, reg.UnsafeWipeAll())
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -56,12 +56,12 @@ func main() {
 	)
 	switch *registryType {
 	case "memory":
-		reg = localregistry.NewLocalRegistry()
+		reg = localregistry.NewLocalRegistry("test-server-id")
 		// Local registry also implements ModuleStore for convenience.
 		moduleStore = reg.(registry.ModuleStore)
 	case "foundationdb":
 		var err error
-		reg, err = fdbregistry.NewFoundationDBRegistry(*foundationDBClusterFilePath)
+		reg, err = fdbregistry.NewFoundationDBRegistry("test-server-id", *foundationDBClusterFilePath)
 		if err != nil {
 			log.Error("error creating FoundationDB registry", slog.Any("error", err))
 			os.Exit(1)

--- a/examples/file_cache/benchmark_test.go
+++ b/examples/file_cache/benchmark_test.go
@@ -35,7 +35,7 @@ func TestFileCacheBenchmark(t *testing.T) {
 		getRangeSize  = 1 << 20
 		fetcher       = newTestFetcher(fileSize, false)
 		cache         = newTestCache()
-		reg           = localregistry.NewLocalRegistry()
+		reg           = localregistry.NewLocalRegistry("test-server-id")
 		moduleStore   = registry.NewNoopModuleStore()
 	)
 	env, err := virtual.NewEnvironment(

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -422,7 +422,7 @@ func TestInvokeActorHostFunctionDeadlockRegression(t *testing.T) {
 // and that the activation/routing system can accomodate all of this.
 func TestHeartbeatAndSelfHealing(t *testing.T) {
 	var (
-		reg         = localregistry.NewLocalRegistry()
+		reg         = localregistry.NewLocalRegistry("test-server-id")
 		moduleStore = newTestModuleStore()
 		ctx         = context.Background()
 	)
@@ -554,9 +554,11 @@ func TestHeartbeatAndSelfHealing(t *testing.T) {
 // rebalance actors across the available nodes based on memory usage.
 func TestHeartbeatAndRebalancingWithMemoryGoModule(t *testing.T) {
 	var (
-		reg = localregistry.NewLocalRegistryWithOptions(registry.KVRegistryOptions{
-			RebalanceMemoryThreshold: 1 << 24,
-		})
+		reg = localregistry.NewLocalRegistryWithOptions(
+			"test-server-id",
+			registry.KVRegistryOptions{
+				RebalanceMemoryThreshold: 1 << 24,
+			})
 		moduleStore = newTestModuleStore()
 		ctx         = context.Background()
 	)
@@ -595,9 +597,11 @@ func TestHeartbeatAndRebalancingWithMemoryGoModule(t *testing.T) {
 // TestHeartbeatAndRebalancingWithMemoryGoModule, but for WASM modules.
 func TestHeartbeatAndRebalancingWithMemoryWASMModule(t *testing.T) {
 	var (
-		reg = localregistry.NewLocalRegistryWithOptions(registry.KVRegistryOptions{
-			RebalanceMemoryThreshold: 1 << 24,
-		})
+		reg = localregistry.NewLocalRegistryWithOptions(
+			"test-server-id",
+			registry.KVRegistryOptions{
+				RebalanceMemoryThreshold: 1 << 24,
+			})
 		moduleStore = newTestModuleStore()
 		ctx         = context.Background()
 	)
@@ -701,9 +705,11 @@ func testHeartbeatAndRebalancingWithMemory(
 // The test verifies that the actor is replicated across multiple environments in a random manner.
 func TestReplicationRandomGoModule(t *testing.T) {
 	var (
-		reg = localregistry.NewLocalRegistryWithOptions(registry.KVRegistryOptions{
-			RebalanceMemoryThreshold: 1 << 24,
-		})
+		reg = localregistry.NewLocalRegistryWithOptions(
+			"test-server-id",
+			registry.KVRegistryOptions{
+				RebalanceMemoryThreshold: 1 << 24,
+			})
 		moduleStore = newTestModuleStore()
 		ctx         = context.Background()
 	)
@@ -735,9 +741,11 @@ func TestReplicationRandomGoModule(t *testing.T) {
 
 func TestReplicationRandomWASMModule(t *testing.T) {
 	var (
-		reg = localregistry.NewLocalRegistryWithOptions(registry.KVRegistryOptions{
-			RebalanceMemoryThreshold: 1 << 24,
-		})
+		reg = localregistry.NewLocalRegistryWithOptions(
+			"test-server-id",
+			registry.KVRegistryOptions{
+				RebalanceMemoryThreshold: 1 << 24,
+			})
 		moduleStore = newTestModuleStore()
 		ctx         = context.Background()
 	)
@@ -844,7 +852,7 @@ func TestCustomHostFns(t *testing.T) {
 func TestGoModulesRegisterTwice(t *testing.T) {
 	// Create environment and register modules.
 	var (
-		reg         = localregistry.NewLocalRegistry()
+		reg         = localregistry.NewLocalRegistry("test-server-id")
 		moduleStore = newTestModuleStore()
 	)
 	env, err := NewEnvironment(context.Background(), "serverID1", reg, moduleStore, nil, defaultOptsGoByte)
@@ -863,7 +871,7 @@ func TestGoModulesRegisterTwice(t *testing.T) {
 // https://github.com/richardartoul/nola/blob/master/proofs/stateright/activation-cache/README.md
 func TestServerVersionIsHonored(t *testing.T) {
 	var (
-		reg         = localregistry.NewLocalRegistry()
+		reg         = localregistry.NewLocalRegistry("test-server-id")
 		moduleStore = newTestModuleStore()
 		ctx         = context.Background()
 	)
@@ -950,7 +958,7 @@ func runWithDifferentConfigs(
 		opts.GCActorsAfterDurationWithNoInvocations = gcDurationOverride
 
 		var (
-			reg         = localregistry.NewLocalRegistry()
+			reg         = localregistry.NewLocalRegistry("test-server-id")
 			moduleStore = newTestModuleStore()
 		)
 		env, err := NewEnvironment(context.Background(), "serverID1", reg, moduleStore, nil, defaultOptsWASM)
@@ -980,7 +988,7 @@ func runWithDifferentConfigs(
 		opts.GCActorsAfterDurationWithNoInvocations = gcDurationOverride
 
 		var (
-			reg         = localregistry.NewLocalRegistry()
+			reg         = localregistry.NewLocalRegistry("test-server-id")
 			moduleStore = newTestModuleStore()
 		)
 		defer reg.Close(context.Background())
@@ -1017,7 +1025,7 @@ func runWithDifferentConfigs(
 		opts.GCActorsAfterDurationWithNoInvocations = gcDurationOverride
 
 		var (
-			reg         = localregistry.NewLocalRegistry()
+			reg         = localregistry.NewLocalRegistry("test-server-id")
 			moduleStore = newTestModuleStore()
 		)
 		defer reg.Close(context.Background())
@@ -1078,7 +1086,7 @@ type testModule struct {
 }
 
 func newTestModuleStore() registry.ModuleStore {
-	return localregistry.NewLocalRegistry().(registry.ModuleStore)
+	return localregistry.NewLocalRegistry("test-server-id").(registry.ModuleStore)
 }
 
 func (tm testModule) Instantiate(

--- a/virtual/registry/dnsregistry/dns_registry.go
+++ b/virtual/registry/dnsregistry/dns_registry.go
@@ -140,10 +140,8 @@ func (d *dnsRegistry) EnsureActivation(
 			"error creating actor reference: %w", err)
 	}
 
-	return registry.EnsureActivationResult{
-		References:   []types.ActorReference{ref},
-		VersionStamp: DNSVersionStamp,
-	}, nil
+	return registry.NewEnsureActivationResult(
+		[]types.ActorReference{ref}, DNSVersionStamp, DNSServerID), nil
 }
 
 func (d *dnsRegistry) GetVersionStamp(

--- a/virtual/registry/fdbregistry/fdb_registry.go
+++ b/virtual/registry/fdbregistry/fdb_registry.go
@@ -3,15 +3,20 @@ package fdbregistry
 import "github.com/richardartoul/nola/virtual/registry"
 
 // NewFoundationDBRegistry creates a new FoundationDB backed registry.
-func NewFoundationDBRegistry(clusterFile string) (registry.Registry, error) {
+func NewFoundationDBRegistry(
+	serverID string,
+	clusterFile string,
+) (registry.Registry, error) {
 	fdbKV, err := newFDBKV(clusterFile)
 	if err != nil {
 		return nil, err
 	}
-	return registry.NewKVRegistry(fdbKV, registry.KVRegistryOptions{
-		// FDB may struggle to make progress on certain workloads if high
-		// conflict operations are enabled because they'll cause excessive
-		// transaction retries / failures.
-		DisableHighConflictOperations: true,
-	}), nil
+	return registry.NewKVRegistry(serverID,
+		fdbKV,
+		registry.KVRegistryOptions{
+			// FDB may struggle to make progress on certain workloads if high
+			// conflict operations are enabled because they'll cause excessive
+			// transaction retries / failures.
+			DisableHighConflictOperations: true,
+		}), nil
 }

--- a/virtual/registry/fdbregistry/fdb_registry_test.go
+++ b/virtual/registry/fdbregistry/fdb_registry_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFDBRegistry(t *testing.T) {
 	registry.TestAllCommon(t, func() registry.Registry {
-		registry, err := NewFoundationDBRegistry("testServerID", "")
+		registry, err := NewFoundationDBRegistry("test-registry-server-id", "")
 		require.NoError(t, err)
 
 		registry.UnsafeWipeAll()
@@ -36,7 +36,7 @@ func testBenchFoundationDBKVGetVersionStamp(
 	// Uncomment to run.
 	t.Skip()
 
-	reg, err := NewFoundationDBRegistry("testServerID", "")
+	reg, err := NewFoundationDBRegistry("test-registry-server-id", "")
 	require.NoError(t, err)
 	require.NoError(t, reg.UnsafeWipeAll())
 

--- a/virtual/registry/fdbregistry/fdb_registry_test.go
+++ b/virtual/registry/fdbregistry/fdb_registry_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFDBRegistry(t *testing.T) {
 	registry.TestAllCommon(t, func() registry.Registry {
-		registry, err := NewFoundationDBRegistry("")
+		registry, err := NewFoundationDBRegistry("testServerID", "")
 		require.NoError(t, err)
 
 		registry.UnsafeWipeAll()
@@ -36,7 +36,7 @@ func testBenchFoundationDBKVGetVersionStamp(
 	// Uncomment to run.
 	t.Skip()
 
-	reg, err := NewFoundationDBRegistry("")
+	reg, err := NewFoundationDBRegistry("testServerID", "")
 	require.NoError(t, err)
 	require.NoError(t, reg.UnsafeWipeAll())
 

--- a/virtual/registry/kv_registry.go
+++ b/virtual/registry/kv_registry.go
@@ -82,10 +82,16 @@ type KVRegistryOptions struct {
 }
 
 // NewKVRegistry creates a new KV-backed registry.
-func NewKVRegistry(kv kv.Store, opts KVRegistryOptions) Registry {
+func NewKVRegistry(
+	serverID string,
+	kv kv.Store,
+	opts KVRegistryOptions,
+) Registry {
 	if opts.Logger == nil {
 		opts.Logger = slog.Default()
 	}
+	opts.Logger = opts.Logger.With(slog.String("server_id", serverID))
+
 	if opts.RebalanceMemoryThreshold <= 0 {
 		opts.RebalanceMemoryThreshold = DefaultRebalanceMemoryThreshold
 	}

--- a/virtual/registry/leaderregistry/leader_registry.go
+++ b/virtual/registry/leaderregistry/leader_registry.go
@@ -33,8 +33,9 @@ type leaderRegistry struct {
 	// clients/servers manually by implementing the leader as a singleton
 	// virtual actor that runs on whatever host happens to be the elected
 	// leader currently.
-	env    virtual.Environment
-	server *virtual.Server
+	env      virtual.Environment
+	server   *virtual.Server
+	serverID string
 }
 
 // LeaderRegistry creates a new leader-backed registry. The idea with the LeaderRegistry is
@@ -100,8 +101,9 @@ func NewLeaderRegistry(
 	}
 
 	return registry.NewValidatedRegistry(&leaderRegistry{
-		env:    env,
-		server: server,
+		env:      env,
+		server:   server,
+		serverID: serverID,
 	}), nil
 }
 
@@ -128,10 +130,8 @@ func (l *leaderRegistry) EnsureActivation(
 		references = append(references, ref)
 	}
 
-	return registry.EnsureActivationResult{
-		References:   references,
-		VersionStamp: ensureActivationResponse.VersionStamp,
-	}, nil
+	return registry.NewEnsureActivationResult(
+		references, ensureActivationResponse.VersionStamp, l.serverID), nil
 }
 
 func (l *leaderRegistry) GetVersionStamp(

--- a/virtual/registry/leaderregistry/leader_registry_test.go
+++ b/virtual/registry/leaderregistry/leader_registry_test.go
@@ -28,7 +28,7 @@ func TestLeaderRegistry(t *testing.T) {
 			Port:          9093,
 		}}
 
-		reg, err := NewLeaderRegistry(context.Background(), lp, "server1", envOpts)
+		reg, err := NewLeaderRegistry(context.Background(), lp, "test-registry-server-id", envOpts)
 		require.NoError(t, err)
 
 		return reg

--- a/virtual/registry/localregistry/local_kv.go
+++ b/virtual/registry/localregistry/local_kv.go
@@ -15,7 +15,6 @@ import (
 // localKV is an implementation of kv backed by local memory.
 type localKV struct {
 	sync.Mutex
-	t time.Time
 	b *btree.BTreeG[btreeKV]
 	// clone of b for current transaction, if any.
 	trClone *btree.BTreeG[btreeKV]

--- a/virtual/registry/localregistry/local_kv.go
+++ b/virtual/registry/localregistry/local_kv.go
@@ -15,6 +15,7 @@ import (
 // localKV is an implementation of kv backed by local memory.
 type localKV struct {
 	sync.Mutex
+	t time.Time
 	b *btree.BTreeG[btreeKV]
 	// clone of b for current transaction, if any.
 	trClone *btree.BTreeG[btreeKV]

--- a/virtual/registry/localregistry/local_kv.go
+++ b/virtual/registry/localregistry/local_kv.go
@@ -143,7 +143,9 @@ func (l *localKV) IterPrefix(
 func (l *localKV) GetVersionStamp() (int64, error) {
 	// Return microseconds since l.t since that will automatically increase at
 	// a rate of ~ 1 million/s just like FDB's versionstamp.
-	return time.Since(l.t).Microseconds(), nil
+	//
+	// Add 1 so we can always treat a versionstamp of 0 as invalid.
+	return time.Since(l.t).Microseconds() + 1, nil
 }
 
 type btreeKV struct {

--- a/virtual/registry/localregistry/local_registry.go
+++ b/virtual/registry/localregistry/local_registry.go
@@ -4,12 +4,15 @@ import "github.com/richardartoul/nola/virtual/registry"
 
 // NewLocalRegistry creates a new local (in-memory) registry. It is primarily used for
 // tests and simple benchmarking.
-func NewLocalRegistry() registry.Registry {
-	return NewLocalRegistryWithOptions(registry.KVRegistryOptions{})
+func NewLocalRegistry(selfID string) registry.Registry {
+	return NewLocalRegistryWithOptions(selfID, registry.KVRegistryOptions{})
 }
 
 // NewLocalRegistryWithOptions is the same as NewLocalRegistry() except it allows the
 // caller to provide KV registry options instead of relying on all the defaults.
-func NewLocalRegistryWithOptions(opts registry.KVRegistryOptions) registry.Registry {
-	return registry.NewKVRegistry(newLocalKV(), opts)
+func NewLocalRegistryWithOptions(
+	selfID string,
+	opts registry.KVRegistryOptions,
+) registry.Registry {
+	return registry.NewKVRegistry(selfID, newLocalKV(), opts)
 }

--- a/virtual/registry/localregistry/local_registry_test.go
+++ b/virtual/registry/localregistry/local_registry_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestLocalRegistry(t *testing.T) {
 	registry.TestAllCommon(t, func() registry.Registry {
-		return NewLocalRegistry("test-id")
+		return NewLocalRegistry("test-registry-server-id")
 	})
 }

--- a/virtual/registry/localregistry/local_registry_test.go
+++ b/virtual/registry/localregistry/local_registry_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestLocalRegistry(t *testing.T) {
 	registry.TestAllCommon(t, func() registry.Registry {
-		return NewLocalRegistry()
+		return NewLocalRegistry("test-id")
 	})
 }

--- a/virtual/registry/test_common.go
+++ b/virtual/registry/test_common.go
@@ -119,6 +119,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		require.Equal(t, "ns1", activations.References[0].Virtual.Namespace)
 		require.Equal(t, "test-module1", activations.References[0].Virtual.ModuleID)
 		require.Equal(t, "a", activations.References[0].Virtual.ActorID)
+		require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
 	}
 
 	// Reuse the same actor ID, but with a different module. The registry should consider
@@ -136,6 +137,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	require.Equal(t, "test-module2", activations.References[0].Virtual.ModuleID)
 	require.Equal(t, "a", activations.References[0].Virtual.ActorID)
 	require.True(t, activations.VersionStamp > prevVS)
+	require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
 
 	// Next 10 activations should all go to server2 for balancing purposes.
 	for i := 0; i < 10; i++ {
@@ -148,6 +150,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		require.NoError(t, err)
 		require.Equal(t, 1, len(activations.References))
 		require.Equal(t, "server2", activations.References[0].Physical.ServerID)
+		require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
 
 		_, err = registry.Heartbeat(ctx, "server2", HeartbeatState{
 			NumActivatedActors: i + 1,
@@ -207,6 +210,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		require.NoError(t, err)
 		require.Equal(t, 1, len(activations.References))
 		require.Equal(t, "server2", activations.References[0].Physical.ServerID)
+		require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
 	}
 }
 

--- a/virtual/registry/test_common.go
+++ b/virtual/registry/test_common.go
@@ -119,7 +119,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		require.Equal(t, "ns1", activations.References[0].Virtual.Namespace)
 		require.Equal(t, "test-module1", activations.References[0].Virtual.ModuleID)
 		require.Equal(t, "a", activations.References[0].Virtual.ActorID)
-		require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
+		require.Equal(t, "test-registry-server-id", activations.RegistryServerID)
 	}
 
 	// Reuse the same actor ID, but with a different module. The registry should consider
@@ -137,7 +137,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	require.Equal(t, "test-module2", activations.References[0].Virtual.ModuleID)
 	require.Equal(t, "a", activations.References[0].Virtual.ActorID)
 	require.True(t, activations.VersionStamp > prevVS)
-	require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
+	require.Equal(t, "test-registry-server-id", activations.RegistryServerID)
 
 	// Next 10 activations should all go to server2 for balancing purposes.
 	for i := 0; i < 10; i++ {
@@ -150,7 +150,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		require.NoError(t, err)
 		require.Equal(t, 1, len(activations.References))
 		require.Equal(t, "server2", activations.References[0].Physical.ServerID)
-		require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
+		require.Equal(t, "test-registry-server-id", activations.RegistryServerID)
 
 		_, err = registry.Heartbeat(ctx, "server2", HeartbeatState{
 			NumActivatedActors: i + 1,
@@ -210,7 +210,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		require.NoError(t, err)
 		require.Equal(t, 1, len(activations.References))
 		require.Equal(t, "server2", activations.References[0].Physical.ServerID)
-		require.Equal(t, "test-registry-server-id", activations.LeaderServerID)
+		require.Equal(t, "test-registry-server-id", activations.RegistryServerID)
 	}
 }
 

--- a/virtual/registry/types.go
+++ b/virtual/registry/types.go
@@ -135,28 +135,28 @@ type EnsureActivationRequest struct {
 
 // EnsureActivationResult contains the result of invoking the EnsureActivation method.
 type EnsureActivationResult struct {
-	References     []types.ActorReference `json:"references"`
-	VersionStamp   int64                  `json:"versionstamp"`
-	LeaderServerID string                 `json:"leader_server_id"`
+	References       []types.ActorReference `json:"references"`
+	VersionStamp     int64                  `json:"versionstamp"`
+	RegistryServerID string                 `json:"registry_server_id"`
 }
 
 // NewEnsureActivationResult creates a new EnsureActivationResult.
 func NewEnsureActivationResult(
 	references []types.ActorReference,
 	versionStamp int64,
-	leaderServerID string,
+	registryServerID string,
 ) EnsureActivationResult {
 	if versionStamp == 0 {
 		panic("VersionStamp cant be 0")
 	}
-	if leaderServerID == "" {
-		panic("LeaderServerID cant be empty")
+	if registryServerID == "" {
+		panic("RegistryServerID cant be empty")
 	}
 
 	return EnsureActivationResult{
-		References:     references,
-		VersionStamp:   versionStamp,
-		LeaderServerID: leaderServerID,
+		References:       references,
+		VersionStamp:     versionStamp,
+		RegistryServerID: registryServerID,
 	}
 }
 

--- a/virtual/registry/types.go
+++ b/virtual/registry/types.go
@@ -135,8 +135,9 @@ type EnsureActivationRequest struct {
 
 // EnsureActivationResult contains the result of invoking the EnsureActivation method.
 type EnsureActivationResult struct {
-	References   []types.ActorReference
-	VersionStamp int64
+	References     []types.ActorReference `json:"references"`
+	VersionStamp   int64                  `json:"versionstamp"`
+	LeaderServerID string                 `json:"leader_server_id"`
 }
 
 // Address is a tuple of net.IP and port so that the implementation can

--- a/virtual/registry/types.go
+++ b/virtual/registry/types.go
@@ -140,6 +140,26 @@ type EnsureActivationResult struct {
 	LeaderServerID string                 `json:"leader_server_id"`
 }
 
+// NewEnsureActivationResult creates a new EnsureActivationResult.
+func NewEnsureActivationResult(
+	references []types.ActorReference,
+	versionStamp int64,
+	leaderServerID string,
+) EnsureActivationResult {
+	if versionStamp == 0 {
+		panic("VersionStamp cant be 0")
+	}
+	if leaderServerID == "" {
+		panic("LeaderServerID cant be empty")
+	}
+
+	return EnsureActivationResult{
+		References:     references,
+		VersionStamp:   versionStamp,
+		LeaderServerID: leaderServerID,
+	}
+}
+
 // Address is a tuple of net.IP and port so that the implementation can
 // be used without assuming every server is running on the same port.
 type Address struct {


### PR DESCRIPTION
When using the leader registry the value of versionstamp is only guaranteed to increase for a given leader. Once a leader transition occurs, the value may reset back. This would cause the activations cache to incorrectly hold on to extremely stale actor references for a long period of time. This P.R fixes the bug by ensuring we only retain the value with the highest version stamp if the server IDs match, otherwise we always accept the upsert.