### PR TITLE
Fix bug where leaderregistry returned wrong server ID on activations result

### DIFF
--- a/virtual/activation_cache.go
+++ b/virtual/activation_cache.go
@@ -286,6 +286,7 @@ func (a *activationsCache) ensureActivationAndUpdateCache(
 			// versionstamp which ensures that we never overwrite the cache with a more
 			// stale result due to async non-determinism.
 			existingAce := existingAceI.(activationCacheEntry)
+			fmt.Println("wtf", actorID, ace.registryServerID, existingAce.registryServerID, ace.registryVersionStamp, existingAce.registryVersionStamp)
 			// Note that it is important that we allow the cache to be overwritten in the
 			// case where existingAce.registryVersionStamp == ace.registryVersionStamp because
 			// some registry implementations like dnsregistry (in the current implementation at

--- a/virtual/registry/test_common.go
+++ b/virtual/registry/test_common.go
@@ -77,6 +77,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	require.Equal(t, "a", activations.References[0].Virtual.ActorID)
 	require.Equal(t, uint64(1), activations.References[0].Virtual.Generation)
 	require.True(t, activations.VersionStamp > 0)
+	require.Equal(t, "test-registry-server-id", activations.RegistryServerID)
 	prevVS := activations.VersionStamp
 
 	activations, err = registry.EnsureActivation(ctx, EnsureActivationRequest{
@@ -92,6 +93,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	require.Equal(t, "test-module1", activations.References[0].Virtual.ModuleID)
 	require.Equal(t, "a", activations.References[0].Virtual.ActorID)
 	require.Equal(t, uint64(1), activations.References[0].Virtual.Generation)
+	require.Equal(t, "test-registry-server-id", activations.RegistryServerID)
 	require.True(t, activations.VersionStamp > prevVS)
 	prevVS = activations.VersionStamp
 


### PR DESCRIPTION
Leader registry always returned the server ID of the node that was running the registry, not the server ID of the node that was the leader and actually served the response which would cause the activation cache to remain stale for a very long time in some cases.