### PR TITLE
Make registry heartbeat TTL configurable

### DIFF
--- a/virtual/environment.go
+++ b/virtual/environment.go
@@ -24,7 +24,6 @@ const (
 	Localhost = "127.0.0.1"
 
 	maxNumActivationsToCache = 1e6 // 1 Million.
-	heartbeatTimeout         = registry.HeartbeatTTL
 )
 
 var (
@@ -33,7 +32,7 @@ var (
 	ErrEnvironmentClosed = errors.New("environment is closed")
 
 	// Var so can be modified by tests.
-	defaultActivationsCacheTTL                    = heartbeatTimeout
+	defaultActivationsCacheTTL                    = registry.DefaultHeartbeatTTL
 	DefaultGCActorsAfterDurationWithNoInvocations = time.Minute
 )
 
@@ -736,7 +735,7 @@ func (r *environment) NumActivatedActors() int {
 }
 
 func (r *environment) Heartbeat() error {
-	ctx, cc := context.WithTimeout(context.Background(), heartbeatTimeout)
+	ctx, cc := context.WithTimeout(context.Background(), r.registry.HeartbeatTTL())
 	defer cc()
 
 	var (

--- a/virtual/environment_test.go
+++ b/virtual/environment_test.go
@@ -780,7 +780,7 @@ func TestServerVersionIsHonored(t *testing.T) {
 
 	env.pauseHeartbeat()
 
-	time.Sleep(registry.HeartbeatTTL + time.Second)
+	time.Sleep(registry.DefaultHeartbeatTTL + time.Second)
 
 	env.resumeHeartbeat()
 

--- a/virtual/registry/dnsregistry/dns_registry.go
+++ b/virtual/registry/dnsregistry/dns_registry.go
@@ -60,6 +60,11 @@ type DNSRegistryOptions struct {
 	// ResolveEvery controls how often the LookupIP method will be
 	// called on the DNSResolver to detect which IPs are active.
 	ResolveEvery time.Duration
+
+	// HeartbeatTTL is the maximum amount of time between server heartbeats before
+	// the registry will consider a server as dead.
+	HeartbeatTTL time.Duration
+
 	// Logger is a logging instance used for logging messages.
 	// If no logger is provided, the default logger from the slog package (slog.Default()) will be used.
 	Logger *slog.Logger
@@ -92,6 +97,9 @@ func NewDNSRegistryFromResolver(
 ) (registry.Registry, error) {
 	if opts.ResolveEvery == 0 {
 		opts.ResolveEvery = 5 * time.Second
+	}
+	if opts.HeartbeatTTL == 0 {
+		opts.HeartbeatTTL = registry.DefaultHeartbeatTTL
 	}
 	if opts.Logger == nil {
 		opts.Logger = slog.Default()
@@ -174,6 +182,10 @@ func (d *dnsRegistry) Close(ctx context.Context) error {
 
 func (d *dnsRegistry) UnsafeWipeAll() error {
 	return nil
+}
+
+func (d *dnsRegistry) HeartbeatTTL() time.Duration {
+	return d.opts.HeartbeatTTL
 }
 
 func (d *dnsRegistry) discover() error {

--- a/virtual/registry/dnsregistry/dns_registry_test.go
+++ b/virtual/registry/dnsregistry/dns_registry_test.go
@@ -2,6 +2,7 @@ package dnsregistry
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"net"
 	"strings"
 	"testing"
@@ -99,4 +100,12 @@ func TestDNSRegistrySingleNode(t *testing.T) {
 	require.Equal(t, "127.0.0.1:9090", activations.References[0].Physical.ServerState.Address)
 	require.Equal(t, DNSServerID, activations.References[0].Physical.ServerID)
 	require.Equal(t, DNSServerVersion, activations.References[0].Physical.ServerVersion)
+}
+
+func TestDNSRegistryTTL(t *testing.T) {
+	reg, err := NewDNSRegistry(Localhost, 9090, DNSRegistryOptions{
+		HeartbeatTTL: 25 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reg.HeartbeatTTL(), 25*time.Millisecond, "Expected heartbeat TTL to be 25ms")
 }

--- a/virtual/registry/leaderregistry/leader_registry.go
+++ b/virtual/registry/leaderregistry/leader_registry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/richardartoul/nola/virtual"
 	"github.com/richardartoul/nola/virtual/registry"
@@ -209,6 +210,10 @@ func (l *leaderRegistry) Close(ctx context.Context) error {
 
 func (l *leaderRegistry) UnsafeWipeAll() error {
 	return errors.New("not implemented")
+}
+
+func (l *leaderRegistry) HeartbeatTTL() time.Duration {
+	return registry.DefaultHeartbeatTTL
 }
 
 type leaderActorModule struct {

--- a/virtual/registry/leaderregistry/leader_registry_test.go
+++ b/virtual/registry/leaderregistry/leader_registry_test.go
@@ -2,6 +2,7 @@ package leaderregistry
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"net"
 	"sync"
 	"testing"
@@ -33,6 +34,13 @@ func TestLeaderRegistry(t *testing.T) {
 
 		return reg
 	})
+}
+
+func TestLeaderRegistryTTL(t *testing.T) {
+	reg, err := NewLeaderRegistry(context.Background(), newTestLeaderProvider(), "test-registry-server-id", virtual.EnvironmentOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, reg.HeartbeatTTL(), registry.DefaultHeartbeatTTL, "Expected leader registry to return default heartbeat TTL of 5s")
 }
 
 type testLeaderProvider struct {

--- a/virtual/registry/leaderregistry/leader_registry_test.go
+++ b/virtual/registry/leaderregistry/leader_registry_test.go
@@ -37,7 +37,11 @@ func TestLeaderRegistry(t *testing.T) {
 }
 
 func TestLeaderRegistryTTL(t *testing.T) {
-	reg, err := NewLeaderRegistry(context.Background(), newTestLeaderProvider(), "test-registry-server-id", virtual.EnvironmentOptions{})
+	envOpts := virtual.EnvironmentOptions{Discovery: virtual.DiscoveryOptions{
+		DiscoveryType: virtual.DiscoveryTypeLocalHost,
+		Port:          9093,
+	}}
+	reg, err := NewLeaderRegistry(context.Background(), newTestLeaderProvider(), "test-registry-server-id", envOpts)
 	require.NoError(t, err)
 
 	assert.Equal(t, reg.HeartbeatTTL(), registry.DefaultHeartbeatTTL, "Expected leader registry to return default heartbeat TTL of 5s")

--- a/virtual/registry/test_common.go
+++ b/virtual/registry/test_common.go
@@ -58,7 +58,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResult.VersionStamp > 0)
-		require.Equal(t, HeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
+		require.Equal(t, DefaultHeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
 	}
 
 	// Should succeed now that we have a server to activate on.
@@ -191,7 +191,7 @@ func testRegistryServiceDiscoveryAndEnsureActivation(t *testing.T, registry Regi
 	//
 	// TODO: Sleeps in tests are bad, but I'm lazy to inject a clock right now and deal
 	//       with all of that.
-	time.Sleep(HeartbeatTTL + time.Second)
+	time.Sleep(DefaultHeartbeatTTL + time.Second)
 
 	// Heartbeat server2. After this, the Registry should only consider server2 to be alive.
 	_, err = registry.Heartbeat(ctx, "server2", HeartbeatState{
@@ -252,7 +252,7 @@ func testRegistryReplication(t *testing.T, registry Registry) {
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResult.VersionStamp > 0)
-		require.Equal(t, HeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
+		require.Equal(t, DefaultHeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
 
 		heartbeatResult, err = registry.Heartbeat(ctx, "server2", HeartbeatState{
 			NumActivatedActors: 10,
@@ -260,7 +260,7 @@ func testRegistryReplication(t *testing.T, registry Registry) {
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResult.VersionStamp > 0)
-		require.Equal(t, HeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
+		require.Equal(t, DefaultHeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
 	}
 
 	activations, err := registry.EnsureActivation(ctx, EnsureActivationRequest{
@@ -312,7 +312,7 @@ func testEnsureActivationPersistence(t *testing.T, registry Registry) {
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResult.VersionStamp > 0)
-		require.Equal(t, HeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
+		require.Equal(t, DefaultHeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
 
 		heartbeatResult, err = registry.Heartbeat(ctx, "server2", HeartbeatState{
 			NumActivatedActors: 10,
@@ -320,7 +320,7 @@ func testEnsureActivationPersistence(t *testing.T, registry Registry) {
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResult.VersionStamp > 0)
-		require.Equal(t, HeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
+		require.Equal(t, DefaultHeartbeatTTL.Microseconds(), heartbeatResult.HeartbeatTTL)
 	}
 
 	go func() {
@@ -338,9 +338,9 @@ func testEnsureActivationPersistence(t *testing.T, registry Registry) {
 				Address:            "server2_address",
 			})
 
-			// Wait for HeartbeatTTL / 2 before sending the next heartbeat
+			// Wait for DefaultHeartbeatTTL / 2 before sending the next heartbeat
 			select {
-			case <-time.After(HeartbeatTTL / 2):
+			case <-time.After(DefaultHeartbeatTTL / 2):
 			case <-ctx.Done():
 				return
 			}

--- a/virtual/registry/types.go
+++ b/virtual/registry/types.go
@@ -3,8 +3,14 @@ package registry
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/richardartoul/nola/virtual/types"
+)
+
+const (
+	// DefaultHeartbeatTTL registry heartbeat TTL that defaults to 5 seconds.
+	DefaultHeartbeatTTL = 5 * time.Second
 )
 
 // Registry is the interface that is implemented by the virtual actor registry.
@@ -43,6 +49,9 @@ type Registry interface {
 	// UnsafeWipeAll wipes the entire registry. Only used for tests. Do not call it anywhere
 	// in production code.
 	UnsafeWipeAll() error
+
+	// HeartbeatTTL returns the configured heartbeat TTL duration.
+	HeartbeatTTL() time.Duration
 }
 
 // CreateActorResult is the result of a call to CreateActor().

--- a/virtual/registry/validator.go
+++ b/virtual/registry/validator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 var (
@@ -121,6 +122,10 @@ func (v *validator) Close(ctx context.Context) error {
 
 func (v *validator) UnsafeWipeAll() error {
 	return v.r.UnsafeWipeAll()
+}
+
+func (v *validator) HeartbeatTTL() time.Duration {
+	return DefaultHeartbeatTTL
 }
 
 func validateString(name, x string) error {


### PR DESCRIPTION
Saw a TODO in `kv_registry.go` that said that it'd be nice if the heartbeat TTL was configurable, so this change acts on that TODO.

I've made all registries that currently take options take in what the heartbeat TTL value should be, and have exposed a `HeartbeatTTL()` function to `environment` such that this value is appropriately passed to `context.WithTimeout` while calling `Heartbeat()` on the environment object. This was previously using the hardcoded default of 5 seconds.

cc @richardartoul 